### PR TITLE
WIP Avoid crashing bpmn-js

### DIFF
--- a/lib/animation/Animation.js
+++ b/lib/animation/Animation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../util/TryCatchUtil').tryCatchAll;
+
 var SVG = require('svg.js');
 
 var domQuery = require('min-dom/lib/query');
@@ -208,7 +210,7 @@ Animation.prototype.hideProcessInstanceAnimations = function(processInstanceId) 
 
 Animation.$inject = [ 'canvas', 'eventBus' ];
 
-module.exports = Animation;
+module.exports = tryCatchAll(Animation);
 
 function _Animation(gfx, waypoints, done) {
   this.gfx = this.fx = gfx;

--- a/lib/features/context-pads/ContextPads.js
+++ b/lib/features/context-pads/ContextPads.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var elementHelper = require('../../util/ElementHelper'),
     isAncestor = elementHelper.isAncestor;
 
@@ -199,4 +201,4 @@ ContextPads.prototype.closeElementContextPads = function(element) {
 
 ContextPads.$inject = [ 'eventBus', 'elementRegistry', 'overlays', 'injector', 'canvas', 'processInstances' ];
 
-module.exports = ContextPads;
+module.exports = tryCatchAll(ContextPads);

--- a/lib/features/disable-modeling/DisableModeling.js
+++ b/lib/features/disable-modeling/DisableModeling.js
@@ -1,19 +1,20 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT;
 
 var HIGH_PRIORITY = 10001;
 
 function DisableModeling(
-    eventBus,
     contextPad,
-    dragging,
     directEditing,
+    dragging,
     editorActions,
+    eventBus,
     modeling,
-    palette,
-    paletteProvider) {
+    palette) {
   var self = this;
 
   this._eventBus = eventBus;
@@ -117,17 +118,16 @@ function DisableModeling(
 }
 
 DisableModeling.$inject = [
-  'eventBus',
   'contextPad',
-  'dragging',
   'directEditing',
+  'dragging',
   'editorActions',
+  'eventBus',
   'modeling',
-  'palette',
-  'paletteProvider',
+  'palette'
 ];
 
-module.exports = DisableModeling;
+module.exports = tryCatchAll(DisableModeling);
 
 // helpers //////////
 

--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 function EditorActions(
     eventBus,
     toggleMode,
@@ -42,4 +44,4 @@ EditorActions.$inject = [
   'editorActions'
 ];
 
-module.exports = EditorActions;
+module.exports = tryCatchAll(EditorActions);

--- a/lib/features/element-notifications/ElementNotifications.js
+++ b/lib/features/element-notifications/ElementNotifications.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify');
 
 var events = require('../../util/EventHelper'),
@@ -80,4 +82,4 @@ ElementNotifications.prototype.removeElementNotification = function(element) {
 
 ElementNotifications.$inject = [ 'overlays', 'eventBus' ];
 
-module.exports = ElementNotifications;
+module.exports = tryCatchAll(ElementNotifications);

--- a/lib/features/element-support/ElementSupport.js
+++ b/lib/features/element-support/ElementSupport.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domClasses = require('min-dom/lib/classes');
 
 var elementHelper = require('../../util/ElementHelper'),
@@ -104,4 +106,4 @@ ElementSupport.prototype.showWarning = function(element) {
 
 ElementSupport.$inject = [ 'eventBus', 'elementRegistry', 'canvas', 'notifications', 'elementNotifications' ];
 
-module.exports = ElementSupport;
+module.exports = tryCatchAll(ElementSupport);

--- a/lib/features/exclusive-gateway-settings/ExclusiveGatewaySettings.js
+++ b/lib/features/exclusive-gateway-settings/ExclusiveGatewaySettings.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var is = require('../../util/ElementHelper').is;
 
 var events = require('../../util/EventHelper'),
@@ -121,4 +123,4 @@ ExclusiveGatewaySettings.prototype.setColor = function(sequenceFlow, color) {
 
 ExclusiveGatewaySettings.$inject = [ 'eventBus', 'elementRegistry', 'graphicsFactory' ];
 
-module.exports = ExclusiveGatewaySettings;
+module.exports = tryCatchAll(ExclusiveGatewaySettings);

--- a/lib/features/keyboard-bindings/KeyboardBindings.js
+++ b/lib/features/keyboard-bindings/KeyboardBindings.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT,
     VERY_HIGH_PRIORITY = 10000;
@@ -67,7 +69,7 @@ function KeyboardBindings(eventBus, injector) {
 
 KeyboardBindings.$inject = [ 'eventBus', 'injector' ];
 
-module.exports = KeyboardBindings;
+module.exports = tryCatchAll(KeyboardBindings);
 
 // helpers //////////
 

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event'),
@@ -211,4 +213,4 @@ Log.prototype.emptyLog = function() {
 
 Log.$inject = [ 'eventBus', 'notifications', 'tokenSimulationPalette', 'canvas' ];
 
-module.exports = Log;
+module.exports = tryCatchAll(Log);

--- a/lib/features/notifications/Notifications.js
+++ b/lib/features/notifications/Notifications.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify');
 
 var events = require('../../util/EventHelper'),
@@ -70,4 +72,4 @@ Notifications.prototype.removeAll = function() {
 
 Notifications.$inject = [ 'eventBus', 'canvas' ];
 
-module.exports = Notifications;
+module.exports = tryCatchAll(Notifications);

--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes');
 
@@ -51,4 +53,4 @@ Palette.prototype.addEntry = function(entry, index) {
 
 Palette.$inject = [ 'eventBus', 'canvas' ];
 
-module.exports = Palette;
+module.exports = tryCatchAll(Palette);

--- a/lib/features/pause-simulation/PauseSimulation.js
+++ b/lib/features/pause-simulation/PauseSimulation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event');
@@ -131,4 +133,4 @@ PauseSimulation.prototype.deactivate = function() {
 
 PauseSimulation.$inject = [ 'eventBus', 'tokenSimulationPalette', 'notifications', 'canvas' ];
 
-module.exports = PauseSimulation;
+module.exports = tryCatchAll(PauseSimulation);

--- a/lib/features/preserve-element-colors/PreserveElementColors.js
+++ b/lib/features/preserve-element-colors/PreserveElementColors.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT;
 
@@ -64,4 +66,4 @@ PreserveElementColors.prototype.setColor = function(element, stroke, fill) {
 
 PreserveElementColors.$inject = [ 'eventBus', 'elementRegistry', 'graphicsFactory' ];
 
-module.exports = PreserveElementColors;
+module.exports = tryCatchAll(PreserveElementColors);

--- a/lib/features/process-instance-ids/ProcessInstanceIds.js
+++ b/lib/features/process-instance-ids/ProcessInstanceIds.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT,
     RESET_SIMULATION_EVENT = events.RESET_SIMULATION_EVENT;
@@ -26,4 +28,4 @@ ProcessInstanceIds.prototype.reset = function() {
 
 ProcessInstanceIds.$inject = [ 'eventBus' ];
 
-module.exports = ProcessInstanceIds;
+module.exports = tryCatchAll(ProcessInstanceIds);

--- a/lib/features/process-instance-settings/ProcessInstanceSettings.js
+++ b/lib/features/process-instance-settings/ProcessInstanceSettings.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT,
     PROCESS_INSTANCE_CREATED_EVENT = events.PROCESS_INSTANCE_CREATED_EVENT,
@@ -119,4 +121,4 @@ ProcessInstanceSettings.prototype.showNext = function(parent) {
 
 ProcessInstanceSettings.$inject = [ 'animation', 'eventBus', 'processInstances', 'elementRegistry' ];
 
-module.exports = ProcessInstanceSettings;
+module.exports = tryCatchAll(ProcessInstanceSettings);

--- a/lib/features/process-instances/ProcessInstances.js
+++ b/lib/features/process-instances/ProcessInstances.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var events = require('../../util/EventHelper'),
     TOGGLE_MODE_EVENT = events.TOGGLE_MODE_EVENT,
     RESET_SIMULATION_EVENT = events.RESET_SIMULATION_EVENT,
@@ -94,4 +96,4 @@ ProcessInstances.prototype.getProcessInstance = function(processInstanceId) {
 
 ProcessInstances.$inject = [ 'eventBus', 'processInstanceIds' ];
 
-module.exports = ProcessInstances;
+module.exports = tryCatchAll(ProcessInstances);

--- a/lib/features/reset-simulation/ResetSimulation.js
+++ b/lib/features/reset-simulation/ResetSimulation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event');
@@ -66,4 +68,4 @@ ResetSimulation.prototype.resetSimulation = function() {
 
 ResetSimulation.$inject = [ 'eventBus', 'tokenSimulationPalette', 'notifications', 'elementRegistry' ];
 
-module.exports = ResetSimulation;
+module.exports = tryCatchAll(ResetSimulation);

--- a/lib/features/set-animation-speed/SetAnimationSpeed.js
+++ b/lib/features/set-animation-speed/SetAnimationSpeed.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event'),
@@ -77,4 +79,4 @@ SetAnimationSpeed.prototype.setActive = function(element) {
 
 SetAnimationSpeed.$inject = [ 'canvas', 'animation', 'eventBus' ];
 
-module.exports = SetAnimationSpeed;
+module.exports = tryCatchAll(SetAnimationSpeed);

--- a/lib/features/show-process-instance/ShowProcessInstance.js
+++ b/lib/features/show-process-instance/ShowProcessInstance.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event'),
@@ -194,4 +196,4 @@ ShowProcessInstance.$inject = [
   'elementRegistry'
 ];
 
-module.exports = ShowProcessInstance;
+module.exports = tryCatchAll(ShowProcessInstance);

--- a/lib/features/simulation-state/SimulationState.js
+++ b/lib/features/simulation-state/SimulationState.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var elementHelper = require('../../util/ElementHelper'),
     getBusinessObject = elementHelper.getBusinessObject,
     is = elementHelper.is,
@@ -169,4 +171,4 @@ SimulationState.$inject = [
   'processInstances'
 ];
 
-module.exports = SimulationState;
+module.exports = tryCatchAll(SimulationState);

--- a/lib/features/toggle-mode/modeler/ToggleMode.js
+++ b/lib/features/toggle-mode/modeler/ToggleMode.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event'),
@@ -70,4 +72,4 @@ ToggleMode.prototype.toggleMode = function() {
 
 ToggleMode.$inject = [ 'eventBus', 'canvas', 'selection', 'contextPad' ];
 
-module.exports = ToggleMode;
+module.exports = tryCatchAll(ToggleMode);

--- a/lib/features/toggle-mode/viewer/ToggleMode.js
+++ b/lib/features/toggle-mode/viewer/ToggleMode.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     domEvent = require('min-dom/lib/event');
@@ -58,4 +60,4 @@ ToggleMode.prototype.toggleMode = function() {
 
 ToggleMode.$inject = [ 'eventBus', 'canvas' ];
 
-module.exports = ToggleMode;
+module.exports = tryCatchAll(ToggleMode);

--- a/lib/features/token-count/TokenCount.js
+++ b/lib/features/token-count/TokenCount.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var domify = require('min-dom/lib/domify');
 
 var elementHelper = require('../../util/ElementHelper'),
@@ -148,4 +150,4 @@ TokenCount.prototype.removeTokenCount = function(element) {
 
 TokenCount.$inject = [ 'eventBus', 'overlays', 'elementRegistry', 'canvas', 'processInstances' ];
 
-module.exports = TokenCount;
+module.exports = tryCatchAll(TokenCount);

--- a/lib/features/token-simulation-behavior/TokenSimulationBehavior.js
+++ b/lib/features/token-simulation-behavior/TokenSimulationBehavior.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var tryCatchAll = require('../../util/TryCatchUtil').tryCatchAll;
+
 var EndEventHandler = require('./handler/EndEventHandler'),
     EventBasedGatewayHandler = require('./handler/EventBasedGatewayHandler'),
     ExclusiveGatewayHandler = require('./handler/ExclusiveGatewayHandler'),
@@ -79,4 +81,4 @@ TokenSimulationBehavior.prototype.registerHandler = function(types, handlerCls) 
 
 TokenSimulationBehavior.$inject = [ 'eventBus', 'animation', 'injector' ];
 
-module.exports = TokenSimulationBehavior;
+module.exports = tryCatchAll(TokenSimulationBehavior);

--- a/lib/util/TryCatchUtil.js
+++ b/lib/util/TryCatchUtil.js
@@ -1,0 +1,77 @@
+var forEach = require('min-dash').forEach,
+    isFunction = require('min-dash').isFunction;
+
+var inherits = require('inherits');
+
+function tryCatch(fn, functionName, callback) {
+  return function() {
+    try {
+      return fn.apply(this, arguments);
+    } catch (err) {
+      if (callback) {
+        callback(functionName, err);
+      } else {
+        console.error(getErrorMessage(functionName), err);
+      }
+    }
+  };
+}
+
+function tryCatchAll(OriginalConstructorFunction, callback) {
+  var prototype = OriginalConstructorFunction.prototype,
+      functionNames = getFunctionNames(prototype);
+
+  var OriginalConstructorFunctionName = OriginalConstructorFunction.prototype.constructor.name;
+
+  forEach(functionNames, function(functionName) {
+    if (!isFunction(prototype[functionName])) {
+      return;
+    }
+
+    prototype[functionName] = tryCatch(
+      prototype[functionName],
+      OriginalConstructorFunctionName + '#' + functionName,
+      callback
+    );
+  });
+
+  function NewConstructorFunction() {
+    try {
+      OriginalConstructorFunction.apply(this, arguments);
+    } catch (err) {
+      var constructorFunctionName = OriginalConstructorFunctionName + '#constructor';
+
+      if (callback) {
+        callback(constructorFunctionName, err);
+      } else {
+        console.error(getErrorMessage(constructorFunctionName), err);
+      }
+    }
+  }
+
+  inherits(NewConstructorFunction, OriginalConstructorFunction);
+
+  if (OriginalConstructorFunction.$inject) {
+    NewConstructorFunction.$inject = OriginalConstructorFunction.$inject;
+  }
+
+  return NewConstructorFunction;
+}
+
+module.exports.tryCatchAll = tryCatchAll;
+
+// helpers //////////
+
+function getFunctionNames(prototype) {
+  var functionNames = [];
+
+  for (var functionName in prototype) {
+    functionNames.push(functionName);
+  }
+
+  return functionNames;
+}
+
+function getErrorMessage(functionName) {
+  return 'Ooops! bpmn-js-token-simulation errored at ' + functionName;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5025,8 +5025,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "webpack-serve": "^2.0.2"
   },
   "dependencies": {
+    "inherits": "^2.0.3",
     "min-dash": "^3.2.0",
     "min-dom": "^0.2.0",
     "svg.js": "^2.6.3"

--- a/test/spec/util/TryCatchUtilSpec.js
+++ b/test/spec/util/TryCatchUtilSpec.js
@@ -1,0 +1,82 @@
+/* global sinon */
+
+var tryCatchAll = require('lib/util/TryCatchUtil').tryCatchAll;
+
+var spy = sinon.spy;
+
+describe('tryCatchAll', function() {
+
+  it('should catch constructor error', function() {
+
+    // given
+    function Foo() {
+      throw new Error();
+    }
+
+    var NewConstructorFunction = tryCatchAll(Foo, function(functionName, err) {
+
+      // then
+      expect(functionName).to.equal('Foo#constructor');
+      expect(err).to.exist;
+    });
+
+    // when
+    new NewConstructorFunction();
+  });
+
+
+  it('should catch method error', function() {
+
+    // given
+    function Foo() {}
+
+    Foo.prototype.foo = function() {
+      throw new Error();
+    };
+
+    var NewConstructorFunction = tryCatchAll(Foo, function(functionName, err) {
+
+      // then
+      expect(functionName).to.equal('Foo#foo');
+      expect(err).to.exist;
+    });
+
+    var foo = new NewConstructorFunction();
+
+    // when
+    foo.foo();
+  });
+
+
+  it('should catch all errors', function() {
+
+    // given
+    var catchSpy = spy();
+
+    function Foo() {
+      throw new Error();
+    }
+
+    Foo.prototype.foo = function() {
+      throw new Error();
+    };
+
+    function Bar(foo) {
+      foo.foo();
+
+      throw new Error();
+    }
+
+    var NewFooConstructorFunction = tryCatchAll(Foo, catchSpy),
+        NewBarConstructorFunction = tryCatchAll(Bar, catchSpy);
+
+    // when
+    var foo = new NewFooConstructorFunction();
+
+    new NewBarConstructorFunction(foo);
+
+    // then
+    expect(catchSpy).to.have.been.calledThrice;
+  });
+
+});


### PR DESCRIPTION
* prevent token simulation from crashing bpmn-js by catching all errors
* constructor functions and methods are proxied and savely executed using `try` and `catch`
* errors are reported in console specifying their exact origin