### PR TITLE
feat(token-simulation): add support for Call Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Check out `localhost:8080`.
 * Event-based Gateway
 * Task
 * Subprocess
+* Call Activity
 
 ## Licence
 

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -46,6 +46,8 @@ function Log(eventBus, notifications, tokenSimulationPalette, canvas) {
       self.log(elementName || 'Script Task', 'info', 'bpmn-icon-script');
     } else if (is(element, 'bpmn:ServiceTask')) {
       self.log(elementName || 'Service Task', 'info', 'bpmn-icon-service');
+    } else if (is(element, 'bpmn:CallActivity')) {
+      self.log(elementName || 'Call Activity', 'info', 'bpmn-icon-call-activity');
     } else if (is(element, 'bpmn:UserTask')) {
       self.log(elementName || 'User Task', 'info', 'bpmn-icon-user');
     } else if (is(element, 'bpmn:ExclusiveGateway')) {

--- a/lib/features/token-simulation-behavior/TokenSimulationBehavior.js
+++ b/lib/features/token-simulation-behavior/TokenSimulationBehavior.js
@@ -37,7 +37,8 @@ function TokenSimulationBehavior(eventBus, animation, injector) {
     'bpmn:ManualTask',
     'bpmn:ScriptTask',
     'bpmn:ServiceTask',
-    'bpmn:UserTask'
+    'bpmn:UserTask',
+    'bpmn:CallActivity'
   ], TaskHandler);
 
   // create animations on generate token

--- a/lib/util/ElementHelper.js
+++ b/lib/util/ElementHelper.js
@@ -87,5 +87,6 @@ module.exports.supportedElements = [
   'bpmn:Task',
   'bpmn:TextAnnotation',
   'bpmn:UserTask',
-  'bpmn:BoundaryEvent'
+  'bpmn:BoundaryEvent',
+  'bpmn:CallActivity'
 ];

--- a/test/spec/SimulationSpec.js
+++ b/test/spec/SimulationSpec.js
@@ -154,9 +154,54 @@ describe('token simulation', function() {
         });
       })();
     });
-
   });
 
+  describe('call-activity', function() {
+
+    const diagram = require('./call-activity.bpmn');
+
+    let startEvent;
+
+    beforeEach(bootstrapModeler(diagram, {
+      additionalModules: [
+        ModelerModule,
+        Animation
+      ]
+    }));
+
+    beforeEach(inject(function(elementRegistry, toggleMode) {
+      startEvent = elementRegistry.get('StartEvent_1');
+
+      toggleMode.toggleMode();
+    }));
+
+    it('should finish simulation at EndEvent_1', function(done) {
+      inject(function(eventBus) {
+
+        // given
+        const log = new Log(eventBus);
+        log.start();
+
+        eventBus.on(PROCESS_INSTANCE_FINISHED_EVENT, ifProcessInstance(1, function() {
+
+          // then
+          expectHistory(log, [
+            'StartEvent_1',
+            'Task_1',
+            'CallActivity_1',
+            'EndEvent_1'
+          ]);
+
+          done();
+        }));
+
+        // when
+        eventBus.fire(GENERATE_TOKEN_EVENT, {
+          element: startEvent
+        });
+      })();
+    });
+  });
 
   describe('subprocess', function() {
 

--- a/test/spec/call-activity.bpmn
+++ b/test/spec/call-activity.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_19vl35g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0o1cygm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1">
+      <bpmn:incoming>SequenceFlow_0o1cygm</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0l36n0f</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_0epigo3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:incoming>SequenceFlow_0l36n0f</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0epigo3</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_0o1cygm" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_0l36n0f" sourceRef="Task_1" targetRef="CallActivity_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_0epigo3" sourceRef="CallActivity_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_117mz73_di" bpmnElement="Task_1">
+        <dc:Bounds x="248" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0gv8wib_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="611" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1iq3nuj_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="401" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0o1cygm_di" bpmnElement="SequenceFlow_0o1cygm">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="248" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0l36n0f_di" bpmnElement="SequenceFlow_0l36n0f">
+        <di:waypoint x="348" y="121" />
+        <di:waypoint x="401" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0epigo3_di" bpmnElement="SequenceFlow_0epigo3">
+        <di:waypoint x="501" y="121" />
+        <di:waypoint x="611" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Adding token simulation support for Call Activity. This will simply pass through the token as discussed in issue #13 