### PR TITLE
Fixes #46

### DIFF
--- a/lib/features/simulation-state/SimulationState.js
+++ b/lib/features/simulation-state/SimulationState.js
@@ -136,7 +136,7 @@ SimulationState.prototype.isFinished = function(element, processInstanceId) {
   var hasAnimations = false;
 
   this._animation.animations.forEach(function(animation) {
-    if (isAncestor(animation.element, parent) &&
+    if (isAncestor(parent, animation.element) &&
         animation.processInstanceId === processInstanceId) {
       hasAnimations = true;
     }


### PR DESCRIPTION
The call to isAncestor(animation.element, parent) always returns false since the element is always a child of the parent.
Should be isAncestor(parent, animation.element) I believe.