### PR TITLE
feat: add minimal token speed difference

### DIFF
--- a/lib/animation/Animation.js
+++ b/lib/animation/Animation.js
@@ -41,6 +41,9 @@ function getSegmentEasing(index, waypoints) {
 
 var DELAY = 0;
 
+var MINIMUM_DURATION = 1250,
+    MAXIMUM_DURATION = 1750;
+
 var EASE_LINEAR = '-',
     EASE_IN = '<',
     EASE_OUT = '>',
@@ -255,7 +258,7 @@ _Animation.prototype.create = function() {
     return length;
   }, 0);
 
-  var todalDuration = 1250;
+  var totalDuration = randomBetween(MINIMUM_DURATION, MAXIMUM_DURATION);
 
   waypoints.forEach(function(waypoint, index) {
     if (index > 0) {
@@ -264,7 +267,7 @@ _Animation.prototype.create = function() {
 
       var ease = getSegmentEasing(index, waypoints);
 
-      var duration = (distance(waypoints[index - 1], waypoint) / totalLength) * todalDuration;
+      var duration = (distance(waypoints[index - 1], waypoint) / totalLength) * totalDuration;
 
       fx = fx
         .animate(duration, ease, DELAY)
@@ -295,3 +298,7 @@ _Animation.prototype.stop = function() {
 _Animation.prototype.setTokenSpeed = function(speed) {
   this.fx._speed = speed;
 };
+
+function randomBetween(min, max) {
+  return min + Math.floor(Math.random() * (max - min));
+}


### PR DESCRIPTION
This ensures tokens do not stack upon each other: 

![capture VMQo5Y_optimized](https://user-images.githubusercontent.com/58601/116304138-8605ce00-a7a2-11eb-9e6d-6279245707a4.gif)

Without this change tokens would always travel at the same speed and look indistinguishable from each other.