### PR TITLE
Es6ify

### DIFF
--- a/lib/animation/index.js
+++ b/lib/animation/index.js
@@ -1,10 +1,13 @@
 import AnimatedBehaviorsModule from './behaviors';
 import ScopeFilterModule from '../features/scope-filter';
+import SimulatorModule from '../simulator';
+
 
 import Animation from './Animation';
 
 export default {
   __depends__: [
+    SimulatorModule,
     AnimatedBehaviorsModule,
     ScopeFilterModule
   ],

--- a/lib/animation/index.js
+++ b/lib/animation/index.js
@@ -2,7 +2,6 @@ import AnimatedBehaviorsModule from './behaviors';
 import ScopeFilterModule from '../features/scope-filter';
 import SimulatorModule from '../simulator';
 
-
 import Animation from './Animation';
 
 export default {

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,0 +1,41 @@
+import SimulatorModule from './simulator';
+import AnimationModule from './animation';
+import ColoredScopesModule from './features/colored-scopes';
+import ContextPadsModule from './features/context-pads';
+import SimulationStateModule from './features/simulation-state';
+import ShowScopesModule from './features/show-scopes';
+import LogModule from './features/log';
+import ElementSupportModule from './features/element-support';
+import PauseSimulationModule from './features/pause-simulation';
+import ResetSimulationModule from './features/reset-simulation';
+import TokenCountModule from './features/token-count';
+import SetAnimationSpeedModule from './features/set-animation-speed';
+
+import ExclusiveGatewaySettings from './features/exclusive-gateway-settings';
+import PreserveElementColors from './features/preserve-element-colors';
+import TokenSimulationPalette from './features/palette';
+
+export default {
+  __depends__: [
+    SimulatorModule,
+    AnimationModule,
+    ColoredScopesModule,
+    ContextPadsModule,
+    SimulationStateModule,
+    ShowScopesModule,
+    LogModule,
+    ElementSupportModule,
+    PauseSimulationModule,
+    ResetSimulationModule,
+    TokenCountModule,
+    SetAnimationSpeedModule
+  ],
+  __init__: [
+    'exclusiveGatewaySettings',
+    'preserveElementColors',
+    'tokenSimulationPalette'
+  ],
+  'exclusiveGatewaySettings': [ 'type', ExclusiveGatewaySettings ],
+  'preserveElementColors': [ 'type', PreserveElementColors ],
+  'tokenSimulationPalette': [ 'type', TokenSimulationPalette ]
+};

--- a/lib/features/context-pads/index.js
+++ b/lib/features/context-pads/index.js
@@ -1,6 +1,13 @@
 import ContextPads from './ContextPads';
 
+import ScopeFilterModule from '../scope-filter';
+
 export default {
-  __init__: [ 'contextPads' ],
+  __depends__: [
+    ScopeFilterModule
+  ],
+  __init__: [
+    'contextPads'
+  ],
   contextPads: [ 'type', ContextPads ]
 };

--- a/lib/features/element-notifications/index.js
+++ b/lib/features/element-notifications/index.js
@@ -1,1 +1,5 @@
-module.exports = require('./ElementNotifications');
+import ElementNotifications from './ElementNotifications';
+
+export default {
+  elementNotifications: [ 'type', ElementNotifications ]
+};

--- a/lib/features/element-support/index.js
+++ b/lib/features/element-support/index.js
@@ -1,9 +1,11 @@
 import ElementSupport from './ElementSupport';
 import ElementNotificationsModule from '../element-notifications';
+import NotificationsModule from '../notifications';
 
 export default {
   __depends__: [
-    ElementNotificationsModule
+    ElementNotificationsModule,
+    NotificationsModule
   ],
   __init__: [ 'elementSupport' ],
   elementSupport: [ 'type', ElementSupport ]

--- a/lib/features/element-support/index.js
+++ b/lib/features/element-support/index.js
@@ -1,6 +1,10 @@
 import ElementSupport from './ElementSupport';
+import ElementNotificationsModule from '../element-notifications';
 
 export default {
+  __depends__: [
+    ElementNotificationsModule
+  ],
   __init__: [ 'elementSupport' ],
   elementSupport: [ 'type', ElementSupport ]
 };

--- a/lib/features/log/index.js
+++ b/lib/features/log/index.js
@@ -1,10 +1,12 @@
 import Log from './Log';
 
+import ScopeFilterModule from '../scope-filter';
 import NotificationsModule from '../notifications';
 
 export default {
   __depends__: [
-    NotificationsModule
+    NotificationsModule,
+    ScopeFilterModule
   ],
   __init__: [
     'log'

--- a/lib/features/log/index.js
+++ b/lib/features/log/index.js
@@ -1,6 +1,11 @@
 import Log from './Log';
 
+import NotificationsModule from '../notifications';
+
 export default {
+  __depends__: [
+    NotificationsModule
+  ],
   __init__: [
     'log'
   ],

--- a/lib/features/pause-simulation/index.js
+++ b/lib/features/pause-simulation/index.js
@@ -1,1 +1,13 @@
-module.exports = require('./PauseSimulation');
+import PauseSimulation from './PauseSimulation';
+
+import NotificationsModule from '../notifications';
+
+export default {
+  __depends__: [
+    NotificationsModule
+  ],
+  __init__: [
+    'pauseSimulation'
+  ],
+  pauseSimulation: [ 'type', PauseSimulation ]
+};

--- a/lib/features/reset-simulation/index.js
+++ b/lib/features/reset-simulation/index.js
@@ -1,1 +1,13 @@
-module.exports = require('./ResetSimulation');
+import ResetSimulation from './ResetSimulation';
+
+import NotificationsModule from '../notifications';
+
+export default {
+  __depends__: [
+    NotificationsModule
+  ],
+  __init__: [
+    'resetSimulation'
+  ],
+  resetSimulation: [ 'type', ResetSimulation ]
+};

--- a/lib/features/set-animation-speed/index.js
+++ b/lib/features/set-animation-speed/index.js
@@ -1,1 +1,8 @@
-module.exports = require('./SetAnimationSpeed');
+import SetAnimationSpeed from './SetAnimationSpeed';
+
+export default {
+  __init__: [
+    'setAnimationSpeed'
+  ],
+  setAnimationSpeed: [ 'type', SetAnimationSpeed ]
+};

--- a/lib/features/show-scopes/index.js
+++ b/lib/features/show-scopes/index.js
@@ -1,6 +1,11 @@
 import ShowScopes from './ShowScopes';
 
+import ScopeFilterModule from '../scope-filter';
+
 export default {
+  __depends__: [
+    ScopeFilterModule
+  ],
   __init__: [
     'showScopes'
   ],

--- a/lib/features/simulation-state/index.js
+++ b/lib/features/simulation-state/index.js
@@ -1,11 +1,15 @@
 import SimulationState from './SimulationState';
 
 import ElementNotificationsModule from '../element-notifications';
+import NotificationsModule from '../notifications';
 
 export default {
   __depends__: [
-    ElementNotificationsModule
+    ElementNotificationsModule,
+    NotificationsModule
   ],
-  __init__: [ 'simulationState' ],
+  __init__: [
+    'simulationState'
+  ],
   simulationState: [ 'type', SimulationState ]
 };

--- a/lib/features/simulation-state/index.js
+++ b/lib/features/simulation-state/index.js
@@ -1,6 +1,11 @@
 import SimulationState from './SimulationState';
 
+import ElementNotificationsModule from '../element-notifications';
+
 export default {
+  __depends__: [
+    ElementNotificationsModule
+  ],
   __init__: [ 'simulationState' ],
   simulationState: [ 'type', SimulationState ]
 };

--- a/lib/features/token-count/index.js
+++ b/lib/features/token-count/index.js
@@ -1,1 +1,13 @@
-module.exports = require('./TokenCount');
+import TokenCount from './TokenCount';
+
+import ScopeFilterModule from '../scope-filter';
+
+export default {
+  __depends__: [
+    ScopeFilterModule
+  ],
+  __init__: [
+    'tokenCount'
+  ],
+  tokenCount: [ 'type', TokenCount ]
+};

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -11,12 +11,12 @@ module.exports = {
     require('./features/element-support').default,
     require('./features/pause-simulation').default,
     require('./features/reset-simulation').default,
-    require('./features/token-count').default
+    require('./features/token-count').default,
+    require('./features/set-animation-speed').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
     'preserveElementColors',
-    'setAnimationSpeed',
     'toggleMode',
     'tokenSimulationEditorActions',
     'tokenSimulationKeyboardBindings',
@@ -24,7 +24,6 @@ module.exports = {
   ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/modeler').default ],
   'tokenSimulationEditorActions': [ 'type', require('./features/editor-actions') ],
   'tokenSimulationKeyboardBindings': [ 'type', require('./features/keyboard-bindings') ],

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -1,31 +1,21 @@
-module.exports = {
+import BaseModule from './base';
+import DisableModelingModule from './features/disable-modeling';
+
+import ToggleMode from './features/toggle-mode/modeler';
+import TokenSimulationEditorActions from './features/editor-actions';
+import TokenSimulationKeyboardBindings from './features/keyboard-bindings';
+
+export default {
   __depends__: [
-    require('./features/disable-modeling').default,
-    require('./simulator').default,
-    require('./animation').default,
-    require('./features/colored-scopes').default,
-    require('./features/context-pads').default,
-    require('./features/simulation-state').default,
-    require('./features/show-scopes').default,
-    require('./features/log').default,
-    require('./features/element-support').default,
-    require('./features/pause-simulation').default,
-    require('./features/reset-simulation').default,
-    require('./features/token-count').default,
-    require('./features/set-animation-speed').default
+    BaseModule,
+    DisableModelingModule
   ],
   __init__: [
-    'exclusiveGatewaySettings',
-    'preserveElementColors',
     'toggleMode',
     'tokenSimulationEditorActions',
-    'tokenSimulationKeyboardBindings',
-    'tokenSimulationPalette'
+    'tokenSimulationKeyboardBindings'
   ],
-  'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
-  'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'toggleMode': [ 'type', require('./features/toggle-mode/modeler').default ],
-  'tokenSimulationEditorActions': [ 'type', require('./features/editor-actions') ],
-  'tokenSimulationKeyboardBindings': [ 'type', require('./features/keyboard-bindings') ],
-  'tokenSimulationPalette': [ 'type', require('./features/palette') ]
+  'toggleMode': [ 'type', ToggleMode ],
+  'tokenSimulationEditorActions': [ 'type', TokenSimulationEditorActions ],
+  'tokenSimulationKeyboardBindings': [ 'type', TokenSimulationKeyboardBindings ]
 };

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -5,20 +5,19 @@ module.exports = {
     require('./animation').default,
     require('./features/colored-scopes').default,
     require('./features/context-pads').default,
-    require('./features/scope-filter').default,
     require('./features/simulation-state').default,
     require('./features/show-scopes').default,
     require('./features/log').default,
     require('./features/element-support').default,
     require('./features/pause-simulation').default,
-    require('./features/reset-simulation').default
+    require('./features/reset-simulation').default,
+    require('./features/token-count').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
     'preserveElementColors',
     'setAnimationSpeed',
     'toggleMode',
-    'tokenCount',
     'tokenSimulationEditorActions',
     'tokenSimulationKeyboardBindings',
     'tokenSimulationPalette'
@@ -27,7 +26,6 @@ module.exports = {
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
   'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/modeler').default ],
-  'tokenCount': [ 'type', require('./features/token-count').default ],
   'tokenSimulationEditorActions': [ 'type', require('./features/editor-actions') ],
   'tokenSimulationKeyboardBindings': [ 'type', require('./features/keyboard-bindings') ],
   'tokenSimulationPalette': [ 'type', require('./features/palette') ]

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -8,15 +8,14 @@ module.exports = {
     require('./features/scope-filter').default,
     require('./features/simulation-state').default,
     require('./features/show-scopes').default,
-    require('./features/notifications').default,
     require('./features/log').default,
-    require('./features/element-support').default
+    require('./features/element-support').default,
+    require('./features/pause-simulation').default,
+    require('./features/reset-simulation').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
-    'pauseSimulation',
     'preserveElementColors',
-    'resetSimulation',
     'setAnimationSpeed',
     'toggleMode',
     'tokenCount',
@@ -25,9 +24,7 @@ module.exports = {
     'tokenSimulationPalette'
   ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
-  'pauseSimulation': [ 'type', require('./features/pause-simulation').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'resetSimulation': [ 'type', require('./features/reset-simulation').default ],
   'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/modeler').default ],
   'tokenCount': [ 'type', require('./features/token-count').default ],

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -13,7 +13,6 @@ module.exports = {
     require('./features/element-support').default
   ],
   __init__: [
-    'elementNotifications',
     'exclusiveGatewaySettings',
     'pauseSimulation',
     'preserveElementColors',
@@ -25,7 +24,6 @@ module.exports = {
     'tokenSimulationKeyboardBindings',
     'tokenSimulationPalette'
   ],
-  'elementNotifications': [ 'type', require('./features/element-notifications').default ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
   'pauseSimulation': [ 'type', require('./features/pause-simulation').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -12,7 +12,6 @@ module.exports = {
     require('./features/element-support').default
   ],
   __init__: [
-    'elementNotifications',
     'exclusiveGatewaySettings',
     'pauseSimulation',
     'preserveElementColors',
@@ -22,7 +21,6 @@ module.exports = {
     'tokenCount',
     'tokenSimulationPalette'
   ],
-  'elementNotifications': [ 'type', require('./features/element-notifications').default ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
   'pauseSimulation': [ 'type', require('./features/pause-simulation').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -1,27 +1,13 @@
-module.exports = {
+import ToggleMode from './features/toggle-mode/viewer';
+
+import BaseModule from './base';
+
+export default {
   __depends__: [
-    require('./simulator').default,
-    require('./animation').default,
-    require('./features/colored-scopes').default,
-    require('./features/context-pads').default,
-    require('./features/scope-filter').default,
-    require('./features/simulation-state').default,
-    require('./features/show-scopes').default,
-    require('./features/log').default,
-    require('./features/element-support').default,
-    require('./features/pause-simulation').default,
-    require('./features/reset-simulation').default,
-    require('./features/token-count').default,
-    require('./features/set-animation-speed').default
+    BaseModule
   ],
   __init__: [
-    'exclusiveGatewaySettings',
-    'preserveElementColors',
-    'toggleMode',
-    'tokenSimulationPalette'
+    'toggleMode'
   ],
-  'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
-  'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'toggleMode': [ 'type', require('./features/toggle-mode/viewer').default ],
-  'tokenSimulationPalette': [ 'type', require('./features/palette') ]
+  'toggleMode': [ 'type', ToggleMode ]
 };

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -7,24 +7,21 @@ module.exports = {
     require('./features/scope-filter').default,
     require('./features/simulation-state').default,
     require('./features/show-scopes').default,
-    require('./features/notifications').default,
     require('./features/log').default,
-    require('./features/element-support').default
+    require('./features/element-support').default,
+    require('./features/pause-simulation').default,
+    require('./features/reset-simulation').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
-    'pauseSimulation',
     'preserveElementColors',
-    'resetSimulation',
     'setAnimationSpeed',
     'toggleMode',
     'tokenCount',
     'tokenSimulationPalette'
   ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
-  'pauseSimulation': [ 'type', require('./features/pause-simulation').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'resetSimulation': [ 'type', require('./features/reset-simulation').default ],
   'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/viewer').default ],
   'tokenCount': [ 'type', require('./features/token-count').default ],

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -11,18 +11,17 @@ module.exports = {
     require('./features/element-support').default,
     require('./features/pause-simulation').default,
     require('./features/reset-simulation').default,
-    require('./features/token-count').default
+    require('./features/token-count').default,
+    require('./features/set-animation-speed').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
     'preserveElementColors',
-    'setAnimationSpeed',
     'toggleMode',
     'tokenSimulationPalette'
   ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
-  'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/viewer').default ],
   'tokenSimulationPalette': [ 'type', require('./features/palette') ]
 };

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -10,20 +10,19 @@ module.exports = {
     require('./features/log').default,
     require('./features/element-support').default,
     require('./features/pause-simulation').default,
-    require('./features/reset-simulation').default
+    require('./features/reset-simulation').default,
+    require('./features/token-count').default
   ],
   __init__: [
     'exclusiveGatewaySettings',
     'preserveElementColors',
     'setAnimationSpeed',
     'toggleMode',
-    'tokenCount',
     'tokenSimulationPalette'
   ],
   'exclusiveGatewaySettings': [ 'type', require('./features/exclusive-gateway-settings').default ],
   'preserveElementColors': [ 'type', require('./features/preserve-element-colors').default ],
   'setAnimationSpeed': [ 'type', require('./features/set-animation-speed').default ],
   'toggleMode': [ 'type', require('./features/toggle-mode/viewer').default ],
-  'tokenCount': [ 'type', require('./features/token-count').default ],
   'tokenSimulationPalette': [ 'type', require('./features/palette') ]
 };


### PR DESCRIPTION
Converts most modules to ES6.

Makes dependencies explicit, where needed.

Provides base token simulation module to build upon with `viewer` and `modeler` distribution versions.