### PR TITLE
Improve example

### DIFF
--- a/example/resources/example.bpmn
+++ b/example/resources/example.bpmn
@@ -169,9 +169,220 @@
   <bpmn:error id="Error_0k93fd1" name="Error_1405ero" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="SequenceFlow_0j9ajgx_di" bpmnElement="SequenceFlow_0j9ajgx">
+        <di:waypoint x="1270" y="416" />
+        <di:waypoint x="1359" y="416" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1314.5" y="395" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rgmhwk_di" bpmnElement="SequenceFlow_0rgmhwk">
+        <di:waypoint x="1065" y="360" />
+        <di:waypoint x="1065" y="416" />
+        <di:waypoint x="1170" y="416" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1080" y="382" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zxk9aa_di" bpmnElement="SequenceFlow_0zxk9aa">
+        <di:waypoint x="1238" y="268" />
+        <di:waypoint x="1377" y="268" />
+        <di:waypoint x="1377" y="211" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1307.5" y="247" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lmdz0d_di" bpmnElement="SequenceFlow_0lmdz0d">
+        <di:waypoint x="1147" y="-184" />
+        <di:waypoint x="1787" y="-184" />
+        <di:waypoint x="1787" y="153" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1467" y="-205" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1364l2a_di" bpmnElement="SequenceFlow_1364l2a">
+        <di:waypoint x="296" y="171" />
+        <di:waypoint x="332" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="314" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zjbpms_di" bpmnElement="SequenceFlow_0zjbpms">
+        <di:waypoint x="1129" y="-123" />
+        <di:waypoint x="1377" y="-123" />
+        <di:waypoint x="1377" y="131" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1253" y="-144.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_091wldx_di" bpmnElement="SequenceFlow_091wldx">
+        <di:waypoint x="357" y="146" />
+        <di:waypoint x="357" y="-123" />
+        <di:waypoint x="719" y="-123" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="362" y="78.75518815120985" width="83" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qdqk69_di" bpmnElement="SequenceFlow_1qdqk69">
+        <di:waypoint x="382" y="171" />
+        <di:waypoint x="490" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="384.49367088607596" y="151" width="84" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_130hgg8_di" bpmnElement="SequenceFlow_130hgg8">
+        <di:waypoint x="163" y="171" />
+        <di:waypoint x="196" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="179.5" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rkllvh_di" bpmnElement="SequenceFlow_0rkllvh">
+        <di:waypoint x="1590" y="268" />
+        <di:waypoint x="1635" y="268" />
+        <di:waypoint x="1635" y="490" />
+        <di:waypoint x="246" y="490" />
+        <di:waypoint x="246" y="211" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1605" y="372.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1p7rbgq_di" bpmnElement="SequenceFlow_1p7rbgq">
+        <di:waypoint x="1731" y="171" />
+        <di:waypoint x="1769" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1750" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10by6md_di" bpmnElement="SequenceFlow_10by6md">
+        <di:waypoint x="1590" y="100" />
+        <di:waypoint x="1681" y="100" />
+        <di:waypoint x="1681" y="131" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1635.5" y="78.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zdc0ci_di" bpmnElement="SequenceFlow_0zdc0ci">
+        <di:waypoint x="1590" y="171" />
+        <di:waypoint x="1631" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1610.5" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jd8d0i_di" bpmnElement="SequenceFlow_0jd8d0i">
+        <di:waypoint x="1496" y="146" />
+        <di:waypoint x="1496" y="100" />
+        <di:waypoint x="1554" y="100" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1511" y="116.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1vsv7r8_di" bpmnElement="SequenceFlow_1vsv7r8">
+        <di:waypoint x="1521" y="171" />
+        <di:waypoint x="1554" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1537.5" y="149" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ftjyrx_di" bpmnElement="SequenceFlow_0ftjyrx">
+        <di:waypoint x="1496" y="196" />
+        <di:waypoint x="1496" y="268" />
+        <di:waypoint x="1554" y="268" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1511" y="225" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1udgk24_di" bpmnElement="SequenceFlow_1udgk24">
+        <di:waypoint x="1427" y="171" />
+        <di:waypoint x="1471" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1449" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yu5yeq_di" bpmnElement="SequenceFlow_1yu5yeq">
+        <di:waypoint x="1295" y="171" />
+        <di:waypoint x="1327" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1311" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ge46mh_di" bpmnElement="SequenceFlow_1ge46mh">
+        <di:waypoint x="1220" y="171" />
+        <di:waypoint x="1259" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1239.5" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1xib75z_di" bpmnElement="SequenceFlow_1xib75z">
+        <di:waypoint x="29" y="171" />
+        <di:waypoint x="63" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="46" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0t9dyy4_di" bpmnElement="SequenceFlow_0t9dyy4">
+        <di:waypoint x="590" y="171" />
+        <di:waypoint x="627" y="171" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="608.5" y="149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="SubProcess_0gc6evc_di" bpmnElement="SubProcess_0gc6evc" isExpanded="true">
         <dc:Bounds x="627" y="0" width="593" height="342" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05m0kip_di" bpmnElement="SequenceFlow_05m0kip">
+        <di:waypoint x="1115" y="221" />
+        <di:waypoint x="1149" y="221" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1132" y="199.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1bpznq3_di" bpmnElement="SequenceFlow_1bpznq3">
+        <di:waypoint x="703" y="221" />
+        <di:waypoint x="732" y="221" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="717.5" y="199.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cx35wm_di" bpmnElement="SequenceFlow_0cx35wm">
+        <di:waypoint x="963" y="221" />
+        <di:waypoint x="1015" y="221" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="944" y="200" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pol4sw_di" bpmnElement="SequenceFlow_1pol4sw">
+        <di:waypoint x="897" y="281" />
+        <di:waypoint x="938" y="281" />
+        <di:waypoint x="938" y="246" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="917.5" y="259.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rz4mzx_di" bpmnElement="SequenceFlow_0rz4mzx">
+        <di:waypoint x="757" y="246" />
+        <di:waypoint x="757" y="281" />
+        <di:waypoint x="797" y="281" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="772" y="257" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dzm18n_di" bpmnElement="SequenceFlow_1dzm18n">
+        <di:waypoint x="897" y="82" />
+        <di:waypoint x="938" y="82" />
+        <di:waypoint x="938" y="196" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="917.5" y="60.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10d6h3a_di" bpmnElement="SequenceFlow_10d6h3a">
+        <di:waypoint x="757" y="196" />
+        <di:waypoint x="757" y="82" />
+        <di:waypoint x="797" y="82" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="772" y="132.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Task_1upmjgh_di" bpmnElement="Task_1upmjgh">
         <dc:Bounds x="797" y="42" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -193,98 +404,24 @@
           <dc:Bounds x="893" y="249" width="0" height="13" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_10d6h3a_di" bpmnElement="SequenceFlow_10d6h3a">
-        <di:waypoint xsi:type="dc:Point" x="757" y="196" />
-        <di:waypoint xsi:type="dc:Point" x="757" y="82" />
-        <di:waypoint xsi:type="dc:Point" x="797" y="82" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="772" y="132.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1dzm18n_di" bpmnElement="SequenceFlow_1dzm18n">
-        <di:waypoint xsi:type="dc:Point" x="897" y="82" />
-        <di:waypoint xsi:type="dc:Point" x="938" y="82" />
-        <di:waypoint xsi:type="dc:Point" x="938" y="196" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="917.5" y="60.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rz4mzx_di" bpmnElement="SequenceFlow_0rz4mzx">
-        <di:waypoint xsi:type="dc:Point" x="757" y="246" />
-        <di:waypoint xsi:type="dc:Point" x="757" y="281" />
-        <di:waypoint xsi:type="dc:Point" x="797" y="281" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="772" y="257" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1pol4sw_di" bpmnElement="SequenceFlow_1pol4sw">
-        <di:waypoint xsi:type="dc:Point" x="897" y="281" />
-        <di:waypoint xsi:type="dc:Point" x="938" y="281" />
-        <di:waypoint xsi:type="dc:Point" x="938" y="246" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="917.5" y="259.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cx35wm_di" bpmnElement="SequenceFlow_0cx35wm">
-        <di:waypoint xsi:type="dc:Point" x="963" y="221" />
-        <di:waypoint xsi:type="dc:Point" x="1015" y="221" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="944" y="200" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0j9yk1o_di" bpmnElement="StartEvent_0j9yk1o">
         <dc:Bounds x="666.8728717366629" y="203" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="652" y="242" width="67" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1bpznq3_di" bpmnElement="SequenceFlow_1bpznq3">
-        <di:waypoint xsi:type="dc:Point" x="703" y="221" />
-        <di:waypoint xsi:type="dc:Point" x="732" y="221" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="717.5" y="199.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_1e8gne7_di" bpmnElement="EndEvent_1e8gne7">
         <dc:Bounds x="1148.872871736663" y="203" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1136" y="242" width="62" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_05m0kip_di" bpmnElement="SequenceFlow_05m0kip">
-        <di:waypoint xsi:type="dc:Point" x="1115" y="221" />
-        <di:waypoint xsi:type="dc:Point" x="1149" y="221" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1132" y="199.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0t9dyy4_di" bpmnElement="SequenceFlow_0t9dyy4">
-        <di:waypoint xsi:type="dc:Point" x="590" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="627" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="608.5" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0offpno_di" bpmnElement="StartEvent_0offpno">
         <dc:Bounds x="-7" y="153" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="-30" y="192" width="83" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1xib75z_di" bpmnElement="SequenceFlow_1xib75z">
-        <di:waypoint xsi:type="dc:Point" x="29" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="63" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="46" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ge46mh_di" bpmnElement="SequenceFlow_1ge46mh">
-        <di:waypoint xsi:type="dc:Point" x="1220" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1259" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1239.5" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_04d3x2w_di" bpmnElement="IntermediateThrowEvent_02yoqsl">
         <dc:Bounds x="1259" y="153" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -294,20 +431,6 @@
       <bpmndi:BPMNShape id="Task_1xu25p5_di" bpmnElement="Task_1xu25p5">
         <dc:Bounds x="1327.1135265700484" y="131" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yu5yeq_di" bpmnElement="SequenceFlow_1yu5yeq">
-        <di:waypoint xsi:type="dc:Point" x="1295" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1327" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1311" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1udgk24_di" bpmnElement="SequenceFlow_1udgk24">
-        <di:waypoint xsi:type="dc:Point" x="1427" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1471" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1449" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EventBasedGateway_1ho472d_di" bpmnElement="ExclusiveGateway_12ylcgi">
         <dc:Bounds x="1471" y="146" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -320,89 +443,27 @@
           <dc:Bounds x="1534" y="289" width="77" height="25" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ftjyrx_di" bpmnElement="SequenceFlow_0ftjyrx">
-        <di:waypoint xsi:type="dc:Point" x="1496" y="196" />
-        <di:waypoint xsi:type="dc:Point" x="1496" y="268" />
-        <di:waypoint xsi:type="dc:Point" x="1554" y="268" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1511" y="225" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_087fl8m_di" bpmnElement="IntermediateCatchEvent_087fl8m">
         <dc:Bounds x="1554" y="153" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1545" y="192" width="54" height="37" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1vsv7r8_di" bpmnElement="SequenceFlow_1vsv7r8">
-        <di:waypoint xsi:type="dc:Point" x="1521" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1554" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1537.5" y="149" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_12qf66u_di" bpmnElement="IntermediateCatchEvent_12qf66u">
         <dc:Bounds x="1554" y="82.38043478260875" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1544" y="121" width="57" height="25" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jd8d0i_di" bpmnElement="SequenceFlow_0jd8d0i">
-        <di:waypoint xsi:type="dc:Point" x="1496" y="146" />
-        <di:waypoint xsi:type="dc:Point" x="1496" y="100" />
-        <di:waypoint xsi:type="dc:Point" x="1554" y="100" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1511" y="116.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Task_0e0mu6c_di" bpmnElement="Task_0e0mu6c">
         <dc:Bounds x="1630.579575596817" y="131" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zdc0ci_di" bpmnElement="SequenceFlow_0zdc0ci">
-        <di:waypoint xsi:type="dc:Point" x="1590" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1631" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1610.5" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10by6md_di" bpmnElement="SequenceFlow_10by6md">
-        <di:waypoint xsi:type="dc:Point" x="1590" y="100" />
-        <di:waypoint xsi:type="dc:Point" x="1681" y="100" />
-        <di:waypoint xsi:type="dc:Point" x="1681" y="131" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1635.5" y="78.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_0swhjpo_di" bpmnElement="EndEvent_0swhjpo">
         <dc:Bounds x="1768.579575596817" y="153" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1746" y="192" width="83" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1p7rbgq_di" bpmnElement="SequenceFlow_1p7rbgq">
-        <di:waypoint xsi:type="dc:Point" x="1731" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="1769" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1750" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rkllvh_di" bpmnElement="SequenceFlow_0rkllvh">
-        <di:waypoint xsi:type="dc:Point" x="1590" y="268" />
-        <di:waypoint xsi:type="dc:Point" x="1635" y="268" />
-        <di:waypoint xsi:type="dc:Point" x="1635" y="490" />
-        <di:waypoint xsi:type="dc:Point" x="246" y="490" />
-        <di:waypoint xsi:type="dc:Point" x="246" y="211" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1605" y="372.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_130hgg8_di" bpmnElement="SequenceFlow_130hgg8">
-        <di:waypoint xsi:type="dc:Point" x="163" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="196" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="179.5" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_1rlipu4_di" bpmnElement="Task_026c0id">
         <dc:Bounds x="63" y="131" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -415,30 +476,28 @@
           <dc:Bounds x="328" y="199" width="58" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1qdqk69_di" bpmnElement="SequenceFlow_1qdqk69" bioc:stroke="#000">
-        <di:waypoint xsi:type="dc:Point" x="382" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="490" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="384.49367088607596" y="151" width="84" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_091wldx_di" bpmnElement="SequenceFlow_091wldx" bioc:stroke="#000">
-        <di:waypoint xsi:type="dc:Point" x="357" y="146" />
-        <di:waypoint xsi:type="dc:Point" x="357" y="-123" />
-        <di:waypoint xsi:type="dc:Point" x="719" y="-123" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="362" y="78.75518815120985" width="83" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="SubProcess_1utqdnk_di" bpmnElement="Task_1ept7kl" isExpanded="true">
         <dc:Bounds x="719" y="-222" width="410" height="197" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zjbpms_di" bpmnElement="SequenceFlow_0zjbpms">
-        <di:waypoint xsi:type="dc:Point" x="1129" y="-123" />
-        <di:waypoint xsi:type="dc:Point" x="1377" y="-123" />
-        <di:waypoint xsi:type="dc:Point" x="1377" y="131" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0z16g3i_di" bpmnElement="SequenceFlow_0z16g3i">
+        <di:waypoint x="1000" y="-119" />
+        <di:waypoint x="1057" y="-119" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1253" y="-144.5" width="0" height="13" />
+          <dc:Bounds x="1028.5" y="-140.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10zdsna_di" bpmnElement="SequenceFlow_10zdsna">
+        <di:waypoint x="929" y="-119" />
+        <di:waypoint x="964" y="-119" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="946.5" y="-140.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_17nxcr4_di" bpmnElement="SequenceFlow_17nxcr4">
+        <di:waypoint x="786" y="-119" />
+        <di:waypoint x="829" y="-119" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="807.5" y="-140.5" width="0" height="13" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_13lmuqn_di" bpmnElement="StartEvent_13lmuqn">
@@ -450,20 +509,6 @@
       <bpmndi:BPMNShape id="Task_180wh31_di" bpmnElement="Task_180wh31">
         <dc:Bounds x="829.4489795918366" y="-159" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_17nxcr4_di" bpmnElement="SequenceFlow_17nxcr4">
-        <di:waypoint xsi:type="dc:Point" x="786" y="-119" />
-        <di:waypoint xsi:type="dc:Point" x="829" y="-119" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="807.5" y="-140.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10zdsna_di" bpmnElement="SequenceFlow_10zdsna">
-        <di:waypoint xsi:type="dc:Point" x="929" y="-119" />
-        <di:waypoint xsi:type="dc:Point" x="964" y="-119" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="946.5" y="-140.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_0wcdcvo_di" bpmnElement="IntermediateThrowEvent_10vhtou">
         <dc:Bounds x="964.4489795918366" y="-137" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -476,56 +521,8 @@
           <dc:Bounds x="1035" y="-98" width="83" height="25" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0z16g3i_di" bpmnElement="SequenceFlow_0z16g3i">
-        <di:waypoint xsi:type="dc:Point" x="1000" y="-119" />
-        <di:waypoint xsi:type="dc:Point" x="1057" y="-119" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1028.5" y="-140.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1364l2a_di" bpmnElement="SequenceFlow_1364l2a">
-        <di:waypoint xsi:type="dc:Point" x="296" y="171" />
-        <di:waypoint xsi:type="dc:Point" x="332" y="171" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="314" y="149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_0m3dsxi_di" bpmnElement="Task_0po6mda">
         <dc:Bounds x="196" y="131" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_1ufpi4t_di" bpmnElement="BoundaryEvent_07intkn">
-        <dc:Bounds x="1111" y="-202" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1152" y="-216" width="47" height="24" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0lmdz0d_di" bpmnElement="SequenceFlow_0lmdz0d">
-        <di:waypoint xsi:type="dc:Point" x="1147" y="-184" />
-        <di:waypoint xsi:type="dc:Point" x="1787" y="-184" />
-        <di:waypoint xsi:type="dc:Point" x="1787" y="153" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1467" y="-205" width="0" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zxk9aa_di" bpmnElement="SequenceFlow_0zxk9aa">
-        <di:waypoint xsi:type="dc:Point" x="1238" y="268" />
-        <di:waypoint xsi:type="dc:Point" x="1377" y="268" />
-        <di:waypoint xsi:type="dc:Point" x="1377" y="211" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1307.5" y="247" width="0" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BoundaryEvent_1di82p3_di" bpmnElement="BoundaryEvent_Error">
-        <dc:Bounds x="1202" y="250" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1243" y="276" width="27" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_14q1ix1_di" bpmnElement="BoundaryEvent_Timer_non_interrupting">
-        <dc:Bounds x="1047" y="324" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1065" y="364" width="0" height="12" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1p2txse_di" bpmnElement="EndEvent_1p2txse">
         <dc:Bounds x="1359" y="397.779" width="36" height="36" />
@@ -533,24 +530,27 @@
           <dc:Bounds x="1377" y="437.779" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rgmhwk_di" bpmnElement="SequenceFlow_0rgmhwk">
-        <di:waypoint xsi:type="dc:Point" x="1065" y="360" />
-        <di:waypoint xsi:type="dc:Point" x="1065" y="416" />
-        <di:waypoint xsi:type="dc:Point" x="1170" y="416" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1080" y="382" width="0" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Task_1u7pqoy_di" bpmnElement="Task_1u7pqoy">
         <dc:Bounds x="1170" y="376" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0j9ajgx_di" bpmnElement="SequenceFlow_0j9ajgx">
-        <di:waypoint xsi:type="dc:Point" x="1270" y="416" />
-        <di:waypoint xsi:type="dc:Point" x="1359" y="416" />
+      <bpmndi:BPMNShape id="BoundaryEvent_14q1ix1_di" bpmnElement="BoundaryEvent_Timer_non_interrupting">
+        <dc:Bounds x="1047" y="324" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1314.5" y="395" width="0" height="12" />
+          <dc:Bounds x="1065" y="364" width="0" height="12" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1di82p3_di" bpmnElement="BoundaryEvent_Error">
+        <dc:Bounds x="1202" y="250" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1243" y="276" width="27" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1ufpi4t_di" bpmnElement="BoundaryEvent_07intkn">
+        <dc:Bounds x="1111" y="-202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1152" y="-216" width="47" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -4,6 +4,8 @@ import BpmnModeler from 'bpmn-js/lib/Modeler';
 
 import fileDrop from 'file-drops';
 
+import fileOpen from 'file-open';
+
 import download from 'downloadjs';
 
 import exampleXML from '../resources/example.bpmn';
@@ -99,19 +101,22 @@ if (presentationMode) {
   document.body.classList.add('presentation-mode');
 }
 
-document.body.addEventListener('dragover', fileDrop('Open BPMN diagram', function(files) {
+function openFile(files) {
 
   // files = [ { name, contents }, ... ]
 
-  if (files.length) {
-    hideDropMessage();
-
-    fileName = files[0].name;
-
-    modeler.openDiagram(files[0].contents);
+  if (!files.length) {
+    return;
   }
 
-}), false);
+  hideDropMessage();
+
+  fileName = files[0].name;
+
+  modeler.openDiagram(files[0].contents);
+}
+
+document.body.addEventListener('dragover', fileDrop('Open BPMN diagram', openFile), false);
 
 function downloadDiagram() {
   modeler.saveXML({ format: true }, function(err, xml) {
@@ -126,6 +131,12 @@ document.body.addEventListener('keydown', function(event) {
     event.preventDefault();
 
     downloadDiagram();
+  }
+
+  if (event.code === 'KeyO' && (event.metaKey || event.ctrlKey)) {
+    event.preventDefault();
+
+    fileOpen().then(openFile);
   }
 });
 

--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -2,6 +2,8 @@ import TokenSimulationModule from '../..';
 
 import BpmnModeler from 'bpmn-js/lib/Modeler';
 
+import AddExporter from '@bpmn-io/add-exporter';
+
 import fileDrop from 'file-drops';
 
 import fileOpen from 'file-open';
@@ -72,8 +74,13 @@ const modeler = new BpmnModeler({
   container: '#canvas',
   additionalModules: [
     TokenSimulationModule,
+    AddExporter,
     ExampleModule
   ],
+  exporter: {
+    name: 'bpmn-js-token-simulation',
+    version: process.env.TOKEN_SIMULATION_VERSION
+  },
   keyboard: {
     bindTo: document
   }

--- a/example/src/viewer.js
+++ b/example/src/viewer.js
@@ -4,6 +4,8 @@ import BpmnViewer from 'bpmn-js/lib/NavigatedViewer';
 
 import fileDrop from 'file-drops';
 
+import fileOpen from 'file-open';
+
 import exampleXML from '../resources/example.bpmn';
 
 
@@ -96,15 +98,27 @@ if (presentationMode) {
   document.body.classList.add('presentation-mode');
 }
 
-document.body.addEventListener('dragover', fileDrop('Open BPMN diagram', function(files) {
+function openFile(files) {
 
   // files = [ { name, contents }, ... ]
 
-  if (files.length) {
-    hideDropMessage();
-    viewer.openDiagram(files[0].contents);
+  if (!files.length) {
+    return;
   }
 
-}), false);
+  hideDropMessage();
+
+  viewer.openDiagram(files[0].contents);
+}
+
+document.body.addEventListener('dragover', fileDrop('Open BPMN diagram', openFile), false);
 
 viewer.openDiagram(initialDiagram);
+
+document.body.addEventListener('keydown', function(event) {
+  if (event.code === 'KeyO' && (event.metaKey || event.ctrlKey)) {
+    event.preventDefault();
+
+    fileOpen().then(openFile);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,6 +3216,12 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-open": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/file-open/-/file-open-0.1.1.tgz",
+      "integrity": "sha512-mKKA/v4ZvDZtGyapWuqS9Asfacc/2dYACn76B+Z5a618DsZa9r59dNnWUDSX5E782XftHo/bTm4eCEa19iDY9w==",
+      "dev": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,6 +352,12 @@
         }
       }
     },
+    "@bpmn-io/add-exporter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/add-exporter/-/add-exporter-0.2.0.tgz",
+      "integrity": "sha512-NryBsKfNIWo7iAHOIXv2y81UCAoHaB6O7zLrGgX1ocIUHHZWtUl6RPOgBx35aCdElWKHwtMAY7xZVhRhtxUorg==",
+      "dev": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "*.css"
   ],
   "devDependencies": {
+    "@bpmn-io/add-exporter": "^0.2.0",
     "bpmn-js": "^8.8.3",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "^7.26.0",
     "eslint-plugin-bpmn-io": "^0.12.0",
     "file-drops": "^0.4.0",
+    "file-open": "^0.1.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.2",
     "karma-chrome-launcher": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var DefinePlugin = require('webpack').DefinePlugin;
+
 
 module.exports = (env, argv) => {
 
@@ -30,6 +32,9 @@ module.exports = (env, argv) => {
           { from: './node_modules/bpmn-js/dist/assets', to: 'dist/vendor/bpmn-js/assets' },
           { from: './assets', to: 'dist/vendor/bpmn-js-token-simulation/assets' }
         ]
+      }),
+      new DefinePlugin({
+        'process.env.TOKEN_SIMULATION_VERSION': JSON.stringify(require('./package.json').version)
       })
     ],
     devtool


### PR DESCRIPTION
Adds the following improvements for our embedded example:

* Serialize exporter
* Allow open via standard open shortcut
* Update diagram (previously contained XML serialization bugs from older bpmn-js + token-simulation versions)