### PR TITLE
Restore context pad scope-filter awareness

### DIFF
--- a/lib/features/context-pads/ContextPads.js
+++ b/lib/features/context-pads/ContextPads.js
@@ -77,18 +77,33 @@ export default function ContextPads(
 
   eventBus.on(SCOPE_FILTER_CHANGED_EVENT, event => {
 
-    const contextPads = domQueryAll(
+    const showElements = domQueryAll(
       '.djs-overlay-ts-context-menu [data-scope-ids]',
       overlays._overlayRoot
     );
 
-    for (const element of contextPads) {
+    for (const element of showElements) {
 
       const scopeIds = element.dataset.scopeIds.split(',');
 
       const shown = scopeIds.some(id => scopeFilter.isShown(id));
 
       domClasses(element).toggle('hidden', !shown);
+    }
+
+
+    const hideElements = domQueryAll(
+      '.djs-overlay-ts-context-menu [data-hide-scope-ids]',
+      overlays._overlayRoot
+    );
+
+    for (const element of hideElements) {
+
+      const scopeIds = element.dataset.hideScopeIds.split(',');
+
+      const shown = scopeIds.some(id => scopeFilter.isShown(id));
+
+      domClasses(element).toggle('hidden', shown);
     }
   });
 
@@ -217,6 +232,7 @@ ContextPads.prototype._updateElementContextPads = function(element, handler) {
     const {
       element,
       scopes: _scopes,
+      hideScopes: _hideScopes,
       action: _action,
       html: _html
     } = contextPad;
@@ -238,6 +254,16 @@ ContextPads.prototype._updateElementContextPads = function(element, handler) {
       const shownScopes = scopes.filter(s => this._scopeFilter.isShown(s));
 
       domClasses(html).toggle('hidden', shownScopes.length === 0);
+    }
+
+    if (_hideScopes) {
+      const scopes = _hideScopes();
+
+      html.dataset.hideScopeIds = scopes.map(s => s.id).join(',');
+
+      const shownScopes = scopes.filter(s => this._scopeFilter.isShown(s));
+
+      domClasses(html).toggle('hidden', shownScopes.length > 0);
     }
 
     if (existingOverlay) {

--- a/lib/features/context-pads/ContextPads.js
+++ b/lib/features/context-pads/ContextPads.js
@@ -41,7 +41,7 @@ export default function ContextPads(
   this._canvas = canvas;
   this._scopeFilter = scopeFilter;
 
-  this._overlaysByElement = new Map();
+  this._overlayCache = new Map();
 
   this._handlerIdx = 0;
 
@@ -140,17 +140,60 @@ ContextPads.prototype.openContextPads = function(parent) {
   });
 };
 
-ContextPads.prototype.registerContextPad = function(element, overlayId) {
+ContextPads.prototype._getOverlays = function(hash) {
+  return this._overlayCache.get(hash) || [];
+};
 
-  const overlaysByElement = this._overlaysByElement;
+ContextPads.prototype._addOverlay = function(element, options) {
 
-  if (!overlaysByElement.has(element)) {
-    overlaysByElement.set(element, []);
+  const {
+    handlerHash
+  } = options;
+
+  if (!handlerHash) {
+    throw new Error('<handlerHash> required');
   }
 
-  const overlayIds = overlaysByElement.get(element);
+  const overlayId = this._overlays.add(element, 'ts-context-menu', {
+    ...options,
+    position: {
+      top: OFFSET_TOP,
+      left: OFFSET_LEFT
+    },
+    show: {
+      minZoom: 0.5
+    }
+  });
 
-  overlayIds.push(overlayId);
+  const overlay = this._overlays.get(overlayId);
+
+  const overlayCache = this._overlayCache;
+
+  if (!overlayCache.has(handlerHash)) {
+    overlayCache.set(handlerHash, []);
+  }
+
+  overlayCache.get(handlerHash).push(overlay);
+};
+
+ContextPads.prototype._removeOverlay = function(overlay) {
+
+  const {
+    id,
+    handlerHash
+  } = overlay;
+
+  // remove overlay
+  this._overlays.remove(id);
+
+  // remove from overlay cache
+  const overlays = this._overlayCache.get(handlerHash) || [];
+
+  const idx = overlays.indexOf(overlay);
+
+  if (idx !== -1) {
+    overlays.splice(idx, 1);
+  }
 };
 
 ContextPads.prototype.updateElementContextPads = function(element) {
@@ -163,9 +206,9 @@ ContextPads.prototype._updateElementContextPads = function(element, handler) {
 
   const contextPads = (handler.createContextPads(element) || []).filter(p => p);
 
-  const type = `ts-context-pad---${element.id}---${handler.hash}`;
+  const handlerHash = `${element.id}------${handler.hash}`;
 
-  const existingOverlays = this._overlays.get({ type });
+  const existingOverlays = this._getOverlays(handlerHash);
 
   const updatedOverlays = [];
 
@@ -216,43 +259,33 @@ ContextPads.prototype._updateElementContextPads = function(element, handler) {
       });
     }
 
-    const overlayId = this._overlays.add(contextPad.element, type, {
-      position: {
-        top: OFFSET_TOP,
-        left: OFFSET_LEFT
-      },
-      html,
+    this._addOverlay(element, {
       hash,
-      show: {
-        minZoom: 0.5
-      }
+      handlerHash,
+      html
     });
-
-    this.registerContextPad(element, overlayId);
   }
 
   for (const existingOverlay of existingOverlays) {
     if (!updatedOverlays.includes(existingOverlay)) {
-      this._overlays.remove(existingOverlay.id);
+      this._removeOverlay(existingOverlay);
     }
   }
 };
 
 ContextPads.prototype.closeContextPads = function() {
-  for (const element of this._overlaysByElement.keys()) {
-    this.closeElementContextPads(element);
+  for (const overlays of this._overlayCache.values()) {
+
+    for (const overlay of overlays) {
+      this._closeOverlay(overlay);
+    }
   }
+
+  this._overlayCache.clear();
 };
 
-ContextPads.prototype.closeElementContextPads = function(element) {
-
-  const overlayIds = this._overlaysByElement.get(element) || [];
-
-  for (const overlayId of overlayIds) {
-    this._overlays.remove(overlayId);
-  }
-
-  overlayIds.length = 0;
+ContextPads.prototype._closeOverlay = function(overlay) {
+  this._overlays.remove(overlay.id);
 };
 
 ContextPads.$inject = [

--- a/lib/features/context-pads/handler/BoundaryEventHandler.js
+++ b/lib/features/context-pads/handler/BoundaryEventHandler.js
@@ -21,10 +21,6 @@ BoundaryEventHandler.prototype.createBoundaryContextPad = function(element) {
     });
   };
 
-  if (!scopes().length) {
-    return;
-  }
-
   const html = `
     <div class="context-pad" title="Trigger Event">
       ${PlayIcon()}

--- a/lib/features/context-pads/handler/ContinueHandler.js
+++ b/lib/features/context-pads/handler/ContinueHandler.js
@@ -17,10 +17,6 @@ ContinueHandler.prototype.createContextPads = function(element) {
     );
   });
 
-  if (!scopes().length) {
-    return;
-  }
-
   const html = `
     <div class="context-pad" title="Trigger Event">
       ${ PlayIcon() }

--- a/lib/features/context-pads/handler/EventBasedGatewayHandler.js
+++ b/lib/features/context-pads/handler/EventBasedGatewayHandler.js
@@ -45,10 +45,6 @@ EventBasedGatewayHandler.prototype.createCatchEventPad = function(element) {
     });
   };
 
-  if (!scopes().length) {
-    return;
-  }
-
   const html = `
     <div class="context-pad" title="Trigger Event">
       ${PlayIcon()}

--- a/lib/features/context-pads/handler/PauseHandler.js
+++ b/lib/features/context-pads/handler/PauseHandler.js
@@ -38,6 +38,7 @@ PauseHandler.prototype.createPauseContextPad = function(element) {
   return {
     action,
     element,
+    hideScopes: scopes,
     html
   };
 };

--- a/lib/features/context-pads/handler/PauseHandler.js
+++ b/lib/features/context-pads/handler/PauseHandler.js
@@ -21,11 +21,6 @@ PauseHandler.prototype.createPauseContextPad = function(element) {
     element
   }).filter(scope => !scope.children.length);
 
-  // only show if no active scope
-  if (scopes().length) {
-    return;
-  }
-
   const wait = this._isPaused(element);
 
   const html = `
@@ -36,10 +31,6 @@ PauseHandler.prototype.createPauseContextPad = function(element) {
   `;
 
   const action = () => {
-
-    if (scopes().length) {
-      return;
-    }
 
     this._togglePaused(element);
   };

--- a/lib/features/context-pads/handler/StartEventHandler.js
+++ b/lib/features/context-pads/handler/StartEventHandler.js
@@ -38,11 +38,6 @@ StartEventHandler.prototype.createStartEventContextPad = function(element, paren
     scopes = () => this._findScopes({
       element: parentElement.parent
     });
-
-    // no parent scope for event sub-process
-    if (!scopes().length) {
-      return;
-    }
   }
 
   const html = `

--- a/lib/features/show-scopes/ShowScopes.js
+++ b/lib/features/show-scopes/ShowScopes.js
@@ -23,16 +23,12 @@ const STROKE_COLOR = '--token-simulation-green-base-44';
 export default function ShowScopes(
     eventBus,
     canvas,
-    graphicsFactory,
-    elementRegistry,
     scopeFilter,
     elementColors,
     simulationStyles) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;
-  this._graphicsFactory = graphicsFactory;
-  this._elementRegistry = elementRegistry;
   this._scopeFilter = scopeFilter;
   this._elementColors = elementColors;
   this._simulationStyles = simulationStyles;
@@ -208,8 +204,6 @@ ShowScopes.prototype._getHighlightColors = function() {
 ShowScopes.$inject = [
   'eventBus',
   'canvas',
-  'graphicsFactory',
-  'elementRegistry',
   'scopeFilter',
   'elementColors',
   'simulationStyles'

--- a/test/spec/SimulationSpec.js
+++ b/test/spec/SimulationSpec.js
@@ -632,7 +632,7 @@ function triggerElement(id) {
   return getBpmnJS().invoke(function(bpmnjs) {
 
     const domElement = domQuery(
-      `.djs-overlays[data-container-id="${id}"] .context-pad`,
+      `.djs-overlays[data-container-id="${id}"] .context-pad:not(.hidden)`,
       bpmnjs._container
     );
 


### PR DESCRIPTION
This PR restores what was previously possible, but optimized away via https://github.com/bpmn-io/bpmn-js-token-simulation/commit/84d288e72ed2217cb196a1002379ac525bedcdc8: Context pads are shown (and hidden) based on the currently selected scope filter.

![capture wq8AST_optimized](https://user-images.githubusercontent.com/58601/146677781-fb6a8f6b-919e-496e-be44-d0ca70ebb0e0.gif)