### PR TITLE
chore: namespace CSS

### DIFF
--- a/assets/css/bpmn-js-token-simulation.css
+++ b/assets/css/bpmn-js-token-simulation.css
@@ -27,7 +27,7 @@
   border-color: var(--token-simulation-red-base-62, #FF3D3D) !important;
 }
 
-.context-pad {
+.bts-context-pad {
   cursor: pointer;
   background-color: var(--token-simulation-grey-lighten-56, #909090);
   border-radius: 2px;
@@ -44,42 +44,43 @@
   box-sizing: border-box;
 }
 
-.context-pad:not(.disabled):hover {
+.bts-context-pad:not(.disabled):hover {
   width: 40px;
   background-color: var(--token-simulation-green-base-44, #10D070);
   opacity: 1;
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.djs-overlays:not(.hover) .context-pad:not(:hover).show-hover,
-.context-pad:not(:hover) .show-hover,
-.context-pad:hover .hide-hover {
+.djs-overlays:not(.hover) .bts-context-pad:not(:hover).show-hover,
+.bts-context-pad:not(:hover) .show-hover,
+.bts-context-pad:hover .hide-hover {
   display: none;
 }
 
-.context-pad.disabled {
+.bts-context-pad.disabled {
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   color: var(--token-simulation-grey-base-40, #666666);
   pointer-events: none;
 }
 
-.context-pad.hidden {
+.bts-context-pad.hidden {
   display: none;
 }
 
-.context-pad [class^="bpmn-icon-"]:before, [class*=" bpmn-icon-"]:before {
+.bts-context-pad [class^="bpmn-icon-"]:before,
+.bts-context-pad [class*=" bpmn-icon-"]:before {
   margin: 0;
 }
 
-.token .text {
+.bts-token .text {
   font-family: 'Arial', sans-serif;
 }
 
-.token-count-parent {
+.bts-token-count-parent {
   white-space: nowrap;
 }
 
-.token-count {
+.bts-token-count {
   background-color: #FAFAFA;
   border-radius: 100%;
   width: 25px;
@@ -89,38 +90,38 @@
   font-size: 14px;
   color: var(--token-simulation-grey-darken-30, #212121);
   user-select: none;
-  animation: jump 1s infinite;
+  animation: bts-jump 1s infinite;
   animation-timing-function: ease;
   position: relative;
   top: 0;
   display: inline-block;
 }
 
-.token-count.inactive {
+.bts-token-count.inactive {
   display: none;
 }
 
-.token-count + .token-count {
+.bts-token-count + .bts-token-count {
   margin-left: -8px;
 }
 
-.token-count.waiting {
+.bts-token-count.waiting {
   color: var(--token-simulation-white, #FFFFFF);
   font-family: 'Arial', sans-serif;
   background-color: var(--token-simulation-green-base-44, #10D070);
 }
 
-@keyframes jump {
+@keyframes bts-jump {
   50% { top: 5px; }
 }
 
-.notifications {
+.bts-notifications {
   position: absolute;
   bottom: 20px;
   left: 20px;
 }
 
-.notifications .notification {
+.bts-notifications .bts-notification {
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   border-radius: 2px;
   padding: 5px 8px;
@@ -134,39 +135,39 @@
   align-items: stretch;
 }
 
-.notifications .notification.info {
+.bts-notifications .bts-notification.info {
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   color: #000;
 }
 
-.notifications .notification.success {
+.bts-notifications .bts-notification.success {
   background-color: var(--token-simulation-green-base-44, #10D070);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.notifications .notification.warning {
+.bts-notifications .bts-notification.warning {
   background-color: var(--token-simulation-red-base-62, #FF3D3D);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.notifications .notification > * {
+.bts-notifications .bts-notification > * {
   flex: initial;
 }
 
-.notifications .notification > :not(:last-child) {
+.bts-notifications .bts-notification > :not(:last-child) {
   margin-right: 6px;
 }
 
-.notifications .notification > .icon {
+.bts-notifications .bts-notification > .bts-icon {
   min-width: 20px;
   text-align: center;
 }
 
-.notifications .notification > .text {
+.bts-notifications .bts-notification > .bts-text {
   flex: 1;
 }
 
-.notifications .notification > .scope {
+.bts-notifications .bts-notification > .bts-scope {
   font-family: monospace;
   font-size: .8em;
   padding: 2px 3px;
@@ -174,16 +175,17 @@
   cursor: default;
 }
 
-.notifications .notification > .icon [class^="bpmn-icon-"]:before, [class*=" bpmn-icon-"]:before {
+.bts-notifications .bts-notification > .bts-icon [class^="bpmn-icon-"]:before,
+.bts-notifications .bts-notification > .bts-icon [class*=" bpmn-icon-"]:before {
   margin: 0;
 }
 
-.bjs-container.paused .play-pause.active {
+.bjs-container.paused .bts-play-pause.active {
   color: var(--token-simulation-silver-darken-94, #EFEFEF);
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
 }
 
-.element-notification {
+.bts-element-notification {
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   color: var(--token-simulation-silver-darken-94, #EFEFEF);
   border-radius: 2px;
@@ -196,26 +198,25 @@
   user-select: none;
 }
 
-.element-notification .fa,
-.element-notification .text {
+.bts-element-notification .bts-text {
   margin: 0 3px 0 3px;
 }
 
-.element-notification .text {
+.bts-element-notification .bts-text {
   white-space: nowrap;
 }
 
-.element-notification.success {
+.bts-element-notification.success {
   background-color: var(--token-simulation-green-base-44, #10D070);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.element-notification.warning {
+.bts-element-notification.warning {
   background-color: var(--token-simulation-red-base-62, #FF3D3D);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.toggle-mode {
+.bts-toggle-mode {
   cursor: pointer;
   position: absolute;
   top: 20px;
@@ -229,13 +230,13 @@
   display: inline-flex;
 }
 
-.toggle-mode .toggle {
+.bts-toggle-mode .bts-toggle {
   margin-left: .25em;
   display: inline-flex;
 }
 
-.bjs-container.simulation .toggle-mode,
-.toggle-mode:hover {
+.bjs-container.simulation .bts-toggle-mode,
+.bts-toggle-mode:hover {
   background-color: var(--token-simulation-green-base-44, #10D070);
   color: var(--token-simulation-white, #FFFFFF);
 }
@@ -255,17 +256,17 @@
   display: none !important;
 }
 
-.token-simulation-palette {
+.bts-palette {
   position: absolute;
   top: 60px;
   left: 20px;
 }
 
-.token-simulation-palette.hidden {
+.bts-palette.hidden {
   display: none;
 }
 
-.token-simulation-palette .entry {
+.bts-palette .bts-entry {
   cursor: pointer;
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   border-radius: 2px;
@@ -282,27 +283,27 @@
   transition: all 0.1s ease;
 }
 
-.token-simulation-palette .entry:last-child {
+.bts-palette .bts-entry:last-child {
   margin-bottom: 0;
 }
 
-.token-simulation-palette .entry:not(.disabled):hover {
+.bts-palette .bts-entry:not(.disabled):hover {
   width: 40px;
   color: var(--token-simulation-white, #FFFFFF);
   background-color: var(--token-simulation-green-base-44, #10D070);
 }
 
-.token-simulation-palette .entry.active {
+.bts-palette .bts-entry.active {
   color: var(--token-simulation-white, #FFFFFF);
   background-color: var(--token-simulation-green-base-44, #10D070);
 }
 
-.token-simulation-palette .entry.disabled {
+.bts-palette .bts-entry.disabled {
   pointer-events: none;
   color: var(--token-simulation-grey-base-40, #666666);
 }
 
-.token-simulation-log {
+.bts-log {
   position: absolute;
   top: 128px;
   bottom: 20px;
@@ -312,47 +313,45 @@
   border-radius: 2px;
   z-index: 10000;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
-.token-simulation-log.hidden {
+.bts-log.hidden {
   display: none;
 }
 
-.token-simulation-log .header {
+.bts-log .bts-header {
   background-color: var(--token-simulation-green-base-44, #10D070);
   padding: 6px 8px;
   color: var(--token-simulation-white, #FFFFFF);
   height: 30px;
   box-sizing: border-box;
   font-size: 16px;
-
+  flex: 0;
   display: flex;
   justify-content: space-between;
 }
 
-.token-simulation-log .header .close {
+.bts-log .bts-close {
   background: none;
   border: none;
   cursor: pointer;
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.token-simulation-log .header .log-icon {
+.bts-log .bts-log-icon {
   cursor: pointer;
 }
 
-.token-simulation-log .content {
-  position: absolute;
+.bts-log .bts-content {
   overflow-y: auto;
   box-sizing: border-box;
-  top: 30px;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  flex: 1;
   padding: 10px;
 }
 
-.token-simulation-log .entry {
+.bts-log .bts-entry {
   font-size: 16px;
   margin: 0 0 6px 0;
   padding: 6px;
@@ -363,48 +362,48 @@
   justify-content: center;
 }
 
-.token-simulation-log .entry.inactive {
+.bts-log .bts-entry.inactive {
   opacity: .5;
 }
 
-.token-simulation-log .entry.success {
+.bts-log .bts-entry.success {
   background-color: var(--token-simulation-green-base-44, #10D070);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.token-simulation-log .entry.success .date,
-.token-simulation-log .entry.warning .date {
+.bts-log .bts-date,
+.bts-log .bts-date {
  color: var(--token-simulation-silver-darken-94, #EFEFEF);
 }
 
-.token-simulation-log .entry.warning {
+.bts-log .bts-entry.warning {
   background-color: var(--token-simulation-red-base-62, #FF3D3D);
   color: var(--token-simulation-white, #FFFFFF);
 }
 
-.token-simulation-log .entry:last-child {
+.bts-log .bts-entry:last-child {
   margin: 0;
 }
 
-.token-simulation-log .entry > * {
+.bts-log .bts-entry > * {
   flex: initial;
 }
 
-.token-simulation-log .entry > :not(:last-child) {
+.bts-log .bts-entry > :not(:last-child) {
   margin-right: 6px;
 }
 
-.token-simulation-log .entry > .date {
+.bts-log .bts-entry > .bts-date {
   min-width: 120px;
   color: var(--token-simulation-grey-base-40, #666666);
 }
 
-.token-simulation-log .entry > .icon {
+.bts-log .bts-entry > .bts-icon {
   min-width: 20px;
   text-align: center;
 }
 
-.token-simulation-log .entry > .scope {
+.bts-log .bts-entry > .bts-scope {
   font-family: monospace;
   font-size: .8em;
   padding: 2px 3px;
@@ -412,15 +411,15 @@
   cursor: default;
 }
 
-.token-simulation-log .entry > .text {
+.bts-log .bts-entry > .bts-text {
   flex: 1;
 }
 
-.token-simulation-log .entry.placeholder.hidden {
+.bts-log .bts-entry.placeholder.hidden {
   display: none;
 }
 
-.token-simulation-scopes {
+.bts-scopes {
   position: absolute;
   top: 22px;
   left: 190px;
@@ -428,11 +427,11 @@
   flex-direction: row;
 }
 
-.token-simulation-scopes.hidden {
+.bts-scopes.hidden {
   display: none;
 }
 
-.token-simulation-scopes .scope {
+.bts-scopes .bts-scope {
   border-radius: 100%;
   width: 25px;
   height: 25px;
@@ -444,11 +443,11 @@
   cursor: pointer;
 }
 
-.token-simulation-scopes .scope.inactive:hover {
+.bts-scopes .bts-scope.inactive:hover {
   opacity: 1
 }
 
-.token-simulation-scopes .scope.inactive {
+.bts-scopes .bts-scope.inactive {
   opacity: .25;
 }
 
@@ -456,7 +455,7 @@
   background-color: var(--token-simulation-silver-base-97, #F8F8F8);
 }
 
-.set-animation-speed {
+.bts-set-animation-speed {
   position: absolute;
   bottom: 20px;
   left: 50%;
@@ -472,20 +471,18 @@
   overflow: hidden;
 }
 
-.set-animation-speed.hidden {
+.bts-set-animation-speed.hidden {
   display: none;
 }
 
-.set-animation-speed .animation-speed-buttons {
+.bts-set-animation-speed .bts-animation-speed-buttons {
   display: flex;
   flex-direction: row;
-}
 
-.set-animation-speed .animation-speed-buttons {
   margin-left: 6px;
 }
 
-.set-animation-speed .animation-speed-buttons .animation-speed-button {
+.bts-set-animation-speed .bts-animation-speed-button {
   padding: 10px 0;
   width: 30px;
   display: inline-flex;
@@ -493,8 +490,8 @@
   border: none;
 }
 
-.set-animation-speed .animation-speed-buttons .animation-speed-button.active,
-.set-animation-speed .animation-speed-buttons .animation-speed-button:hover {
+.bts-set-animation-speed .bts-animation-speed-button.active,
+.bts-set-animation-speed .bts-animation-speed-button:hover {
   background-color: var(--token-simulation-green-base-44, #10D070);
   color: var(--token-simulation-white, #FFFFFF);
 }

--- a/example/style.css
+++ b/example/style.css
@@ -12,7 +12,7 @@ html, body, #canvas {
   color: var(--token-simulation-grey-darken-30, #212121);
 }
 
-:not(.presentation-mode) .notifications {
+:not(.presentation-mode) .bts-notifications {
   bottom: 60px;
 }
 

--- a/lib/animation/Animation.js
+++ b/lib/animation/Animation.js
@@ -73,7 +73,7 @@ export default function Animation(canvas, eventBus, scopeFilter) {
     const viewport = domQuery('.viewport', canvas._svg);
 
     this.group = svgAppendTo(
-      svgCreate('<g class="animation-tokens" />'),
+      svgCreate('<g class="bts-animation-tokens" />'),
       viewport
     );
   });
@@ -195,16 +195,16 @@ Animation.prototype._getTokenSVG = function(scope) {
   };
 
   return `
-    <g class="token">
+    <g class="bts-token">
       <circle
-        class="circle"
+        class="bts-circle"
         r="${TOKEN_SIZE / 2}"
         cx="${TOKEN_SIZE / 2}"
         cy="${TOKEN_SIZE / 2}"
         fill="${ colors.primary }"
       />
       <text
-        class="text"
+        class="bts-text"
         transform="translate(10, 14)"
         text-anchor="middle"
         fill="${ colors.auxiliary }"

--- a/lib/features/context-pads/handler/BoundaryEventHandler.js
+++ b/lib/features/context-pads/handler/BoundaryEventHandler.js
@@ -22,7 +22,7 @@ BoundaryEventHandler.prototype.createBoundaryContextPad = function(element) {
   };
 
   const html = `
-    <div class="context-pad" title="Trigger Event">
+    <div class="bts-context-pad" title="Trigger Event">
       ${PlayIcon()}
     </div>
   `;

--- a/lib/features/context-pads/handler/ContinueHandler.js
+++ b/lib/features/context-pads/handler/ContinueHandler.js
@@ -18,7 +18,7 @@ ContinueHandler.prototype.createContextPads = function(element) {
   });
 
   const html = `
-    <div class="context-pad" title="Trigger Event">
+    <div class="bts-context-pad" title="Trigger Event">
       ${ PlayIcon() }
     </div>
   `;

--- a/lib/features/context-pads/handler/EventBasedGatewayHandler.js
+++ b/lib/features/context-pads/handler/EventBasedGatewayHandler.js
@@ -46,7 +46,7 @@ EventBasedGatewayHandler.prototype.createCatchEventPad = function(element) {
   };
 
   const html = `
-    <div class="context-pad" title="Trigger Event">
+    <div class="bts-context-pad" title="Trigger Event">
       ${PlayIcon()}
     </div>
   `;

--- a/lib/features/context-pads/handler/ExclusiveGatewayHandler.js
+++ b/lib/features/context-pads/handler/ExclusiveGatewayHandler.js
@@ -22,7 +22,7 @@ ExclusiveGatewayHandler.prototype.createContextPads = function(element) {
   }
 
   const html = `
-    <div class="context-pad" title="Set Sequence Flow">
+    <div class="bts-context-pad" title="Set Sequence Flow">
       ${ForkIcon()}
     </div>
   `;

--- a/lib/features/context-pads/handler/PauseHandler.js
+++ b/lib/features/context-pads/handler/PauseHandler.js
@@ -24,7 +24,7 @@ PauseHandler.prototype.createPauseContextPad = function(element) {
   const wait = this._isPaused(element);
 
   const html = `
-    <div class="context-pad ${ wait ? '' : 'show-hover' }" title="${ wait ? 'Remove' : 'Add' } pause point">
+    <div class="bts-context-pad ${ wait ? '' : 'show-hover' }" title="${ wait ? 'Remove' : 'Add' } pause point">
       ${ (wait ? RemovePauseIcon : PauseIcon)('show-hover') }
       ${ PauseIcon('hide-hover') }
     </div>

--- a/lib/features/context-pads/handler/StartEventHandler.js
+++ b/lib/features/context-pads/handler/StartEventHandler.js
@@ -41,7 +41,7 @@ StartEventHandler.prototype.createStartEventContextPad = function(element, paren
   }
 
   const html = `
-    <div class="context-pad">
+    <div class="bts-context-pad">
       ${PlayIcon()}
     </div>
   `;

--- a/lib/features/element-notifications/ElementNotifications.js
+++ b/lib/features/element-notifications/ElementNotifications.js
@@ -44,9 +44,9 @@ ElementNotifications.prototype.addElementNotification = function(element, option
     : '';
 
   const html = domify(`
-    <div class="element-notification ${ type || '' }" ${colorMarkup}>
+    <div class="bts-element-notification ${ type || '' }" ${colorMarkup}>
       ${ icon || '' }
-      <span class="text">${ text }</span>
+      <span class="bts-text">${ text }</span>
     </div>
   `);
 

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -58,7 +58,7 @@ export default function Log(
   this._init();
 
   eventBus.on(SCOPE_FILTER_CHANGED_EVENT, event => {
-    const allElements = domQueryAll('.entry[data-scope-id]', this._container);
+    const allElements = domQueryAll('.bts-entry[data-scope-id]', this._container);
 
     for (const element of allElements) {
       const scopeId = element.dataset.scopeId;
@@ -264,22 +264,22 @@ export default function Log(
 
 Log.prototype._init = function() {
   this._container = domify(`
-    <div class="token-simulation-log hidden">
-      <div class="header">
-        ${ LogIcon('log-icon') }
-        <button class="close">
+    <div class="bts-log hidden">
+      <div class="bts-header">
+        ${ LogIcon('bts-log-icon') }
+        <button class="bts-close">
           ${ TimesIcon() }
         </button>
       </div>
-      <div class="content">
-        <p class="entry placeholder">No Entries</p>
+      <div class="bts-content">
+        <p class="bts-entry placeholder">No Entries</p>
       </div>
     </div>
   `);
 
-  this._placeholder = domQuery('.placeholder', this._container);
+  this._placeholder = domQuery('.bts-placeholder', this._container);
 
-  this._content = domQuery('.content', this._container);
+  this._content = domQuery('.bts-content', this._container);
 
   domEvent.bind(this._content, 'wheel', event => {
     event.stopPropagation();
@@ -289,13 +289,13 @@ Log.prototype._init = function() {
     event.stopPropagation();
   });
 
-  this._close = domQuery('.close', this._container);
+  this._close = domQuery('.bts-close', this._container);
 
   domEvent.bind(this._close, 'click', () => {
     domClasses(this._container).add('hidden');
   });
 
-  this._icon = domQuery('.log-icon', this._container);
+  this._icon = domQuery('.bts-log-icon', this._container);
 
   domEvent.bind(this._icon, 'click', () => {
     domClasses(this._container).add('hidden');
@@ -304,7 +304,7 @@ Log.prototype._init = function() {
   this._canvas.getContainer().appendChild(this._container);
 
   this.paletteEntry = domify(`
-    <div class="entry" title="Show Simulation Log">
+    <div class="bts-entry" title="Show Simulation Log">
       ${ LogIcon() }
     </div>
   `);
@@ -350,23 +350,23 @@ Log.prototype.log = function(options) {
   const colorMarkup = colors ? `style="background: ${colors.primary}; color: ${colors.auxiliary}"` : '';
 
   const logEntry = domify(`
-    <p class="entry ${ type } ${
+    <p class="bts-entry ${ type } ${
       scope && this._scopeFilter.isShown(scope) ? '' : 'inactive'
     }" ${
       scope ? `data-scope-id="${scope.id}"` : ''
     }>
-      <span class="date">${ dateString }</span>
-      <span class="icon">${iconMarkup}</span>
-      <span class="text">${text}</span>
+      <span class="bts-date">${ dateString }</span>
+      <span class="bts-icon">${iconMarkup}</span>
+      <span class="bts-text">${text}</span>
       ${
         scope
-          ? `<span class="scope" data-scope-id="${scope.id}" ${colorMarkup}>${scope.id}</span>`
+          ? `<span class="bts-scope" data-scope-id="${scope.id}" ${colorMarkup}>${scope.id}</span>`
           : ''
       }
     </p>
   `);
 
-  domDelegate.bind(logEntry, '.scope[data-scope-id]', 'click', event => {
+  domDelegate.bind(logEntry, '.bts-scope[data-scope-id]', 'click', event => {
     this._scopeFilter.toggle(scope);
   });
 
@@ -380,7 +380,7 @@ Log.prototype.clear = function() {
     this._content.removeChild(this._content.firstChild);
   }
 
-  this._placeholder = domify('<p class="entry placeholder">No Entries</p>');
+  this._placeholder = domify('<p class="bts-entry placeholder">No Entries</p>');
 
   this._content.appendChild(this._placeholder);
 };

--- a/lib/features/notifications/Notifications.js
+++ b/lib/features/notifications/Notifications.js
@@ -33,7 +33,7 @@ export default function Notifications(eventBus, canvas, scopeFilter) {
 }
 
 Notifications.prototype._init = function() {
-  this.container = domify('<div class="notifications"></div>');
+  this.container = domify('<div class="bts-notifications"></div>');
 
   this._canvas.getContainer().appendChild(this.container);
 };
@@ -61,10 +61,10 @@ Notifications.prototype.showNotification = function(options) {
   const colorMarkup = colors ? `style="color: ${colors.auxiliary}; background: ${colors.primary}"` : '';
 
   const notification = domify(`
-    <div class="notification ${type}">
-      <span class="icon">${iconMarkup}</span>
-      <span class="text">${text}</span>
-      ${ scope ? `<span class="scope" ${colorMarkup}>${scope.id}</span>` : '' }
+    <div class="bts-notification ${type}">
+      <span class="bts-icon">${iconMarkup}</span>
+      <span class="bts-text">${text}</span>
+      ${ scope ? `<span class="bts-scope" ${colorMarkup}>${scope.id}</span>` : '' }
     </div>
   `);
 

--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -29,7 +29,7 @@ export default function Palette(eventBus, canvas) {
 }
 
 Palette.prototype._init = function() {
-  this.container = domify('<div class="token-simulation-palette hidden"></div>');
+  this.container = domify('<div class="bts-palette hidden"></div>');
 
   this._canvas.getContainer().appendChild(this.container);
 };

--- a/lib/features/pause-simulation/PauseSimulation.js
+++ b/lib/features/pause-simulation/PauseSimulation.js
@@ -61,7 +61,7 @@ export default function PauseSimulation(
 
 PauseSimulation.prototype._init = function() {
   this.paletteEntry = domify(`
-    <div class="entry disabled" title="Play/Pause Simulation">
+    <div class="bts-entry disabled" title="Play/Pause Simulation">
       ${ PLAY_MARKUP }
     </div>
   `);

--- a/lib/features/reset-simulation/ResetSimulation.js
+++ b/lib/features/reset-simulation/ResetSimulation.js
@@ -37,7 +37,7 @@ export default function ResetSimulation(eventBus, tokenSimulationPalette, notifi
 
 ResetSimulation.prototype._init = function() {
   this._paletteEntry = domify(`
-    <div class="entry disabled" title="Reset Simulation">
+    <div class="bts-entry disabled" title="Reset Simulation">
       ${ ResetIcon() }
     </div>
   `);

--- a/lib/features/set-animation-speed/SetAnimationSpeed.js
+++ b/lib/features/set-animation-speed/SetAnimationSpeed.js
@@ -50,12 +50,12 @@ SetAnimationSpeed.prototype.getToggleSpeed = function(element) {
 
 SetAnimationSpeed.prototype._init = function(animationSpeed) {
   this._container = domify(`
-    <div class="set-animation-speed hidden">
+    <div class="bts-set-animation-speed hidden">
       ${ TachometerIcon() }
-      <div class="animation-speed-buttons">
+      <div class="bts-animation-speed-buttons">
         ${
           SPEEDS.map(([ label, speed ], idx) => `
-            <button title="Set animation speed = ${ label }" data-speed="${ speed }" class="animation-speed-button ${speed === animationSpeed ? 'active' : ''}">
+            <button title="Set animation speed = ${ label }" data-speed="${ speed }" class="bts-animation-speed-button ${speed === animationSpeed ? 'active' : ''}">
               ${
                 Array.from({ length: idx + 1 }).map(
                   () => AngleRightIcon()

--- a/lib/features/show-scopes/ShowScopes.js
+++ b/lib/features/show-scopes/ShowScopes.js
@@ -79,7 +79,7 @@ export default function ShowScopes(
 }
 
 ShowScopes.prototype._init = function() {
-  this._container = domify('<div class="token-simulation-scopes hidden"></div>');
+  this._container = domify('<div class="bts-scopes hidden"></div>');
 
   this._canvas.getContainer().appendChild(this._container);
 };
@@ -105,7 +105,7 @@ ShowScopes.prototype.addScope = function(scope) {
   const colorMarkup = colors ? `style="color: ${colors.auxiliary}; background: ${colors.primary}"` : '';
 
   const html = domify(`
-    <div data-scope-id="${scope.id}" class="scope"
+    <div data-scope-id="${scope.id}" class="bts-scope"
          title="View Process Instance ${scope.id}" ${colorMarkup}>
       ${scope.getTokens()}
     </div>

--- a/lib/features/toggle-mode/modeler/ToggleMode.js
+++ b/lib/features/toggle-mode/modeler/ToggleMode.js
@@ -47,8 +47,8 @@ export default function ToggleMode(
 
 ToggleMode.prototype._init = function() {
   this._container = domify(`
-    <div class="toggle-mode">
-      Token Simulation <span class="toggle">${ ToggleOffIcon() }</span>
+    <div class="bts-toggle-mode">
+      Token Simulation <span class="bts-toggle">${ ToggleOffIcon() }</span>
     </div>
   `);
 
@@ -64,12 +64,12 @@ ToggleMode.prototype.toggleMode = function(active = !this._active) {
   }
 
   if (active) {
-    this._container.innerHTML = `Token Simulation <span class="toggle">${ ToggleOnIcon() }</span>`;
+    this._container.innerHTML = `Token Simulation <span class="bts-toggle">${ ToggleOnIcon() }</span>`;
 
     domClasses(this._canvasParent).add('simulation');
     domClasses(this._palette).add('hidden');
   } else {
-    this._container.innerHTML = `Token Simulation <span class="toggle">${ ToggleOffIcon() }</span>`;
+    this._container.innerHTML = `Token Simulation <span class="bts-toggle">${ ToggleOffIcon() }</span>`;
 
     domClasses(this._canvasParent).remove('simulation');
     domClasses(this._palette).remove('hidden');

--- a/lib/features/toggle-mode/viewer/ToggleMode.js
+++ b/lib/features/toggle-mode/viewer/ToggleMode.js
@@ -51,8 +51,8 @@ export default function ToggleMode(eventBus, canvas, selection) {
 
 ToggleMode.prototype._init = function() {
   this._container = domify(`
-    <div class="toggle-mode">
-      Token Simulation <span class="toggle">${ ToggleOffIcon() }</span>
+    <div class="bts-toggle-mode">
+      Token Simulation <span class="bts-toggle">${ ToggleOffIcon() }</span>
     </div>
   `);
 
@@ -67,11 +67,11 @@ ToggleMode.prototype.toggleMode = function(active = !this._active) {
   }
 
   if (active) {
-    this._container.innerHTML = `Token Simulation <span class="toggle">${ ToggleOnIcon() }</span>`;
+    this._container.innerHTML = `Token Simulation <span class="bts-toggle">${ ToggleOnIcon() }</span>`;
 
     domClasses(this._canvasParent).add('simulation');
   } else {
-    this._container.innerHTML = `Token Simulation <span class="toggle">${ ToggleOffIcon() }</span>`;
+    this._container.innerHTML = `Token Simulation <span class="bts-toggle">${ ToggleOffIcon() }</span>`;
 
     domClasses(this._canvasParent).remove('simulation');
   }

--- a/lib/features/token-count/TokenCount.js
+++ b/lib/features/token-count/TokenCount.js
@@ -47,7 +47,7 @@ export default function TokenCount(
 
   eventBus.on(SCOPE_FILTER_CHANGED_EVENT, event => {
 
-    const allElements = domQueryAll('.token-count[data-scope-id]', overlays._overlayRoot);
+    const allElements = domQueryAll('.bts-token-count[data-scope-id]', overlays._overlayRoot);
 
     for (const element of allElements) {
       const scopeId = element.dataset.scopeId;
@@ -83,7 +83,7 @@ TokenCount.prototype.addTokenCount = function(element, scopes) {
   }).join('');
 
   const html = domify(`
-    <div class="token-count-parent">
+    <div class="bts-token-count-parent">
       ${tokenMarkup}
     </div>
   `);
@@ -122,7 +122,7 @@ TokenCount.prototype._getTokenHTML = function(element, scope) {
   const colors = scope.colors || this._getDefaultColors();
 
   return `
-    <div data-scope-id="${scope.id}" class="token-count waiting ${this._scopeFilter.isShown(scope) ? '' : 'inactive' }"
+    <div data-scope-id="${scope.id}" class="bts-token-count waiting ${this._scopeFilter.isShown(scope) ? '' : 'inactive' }"
          style="color: ${colors.auxiliary}; background: ${ colors.primary }">
       ${scope.getTokensByElement(element)}
     </div>

--- a/test/spec/SimulationSpec.js
+++ b/test/spec/SimulationSpec.js
@@ -632,7 +632,7 @@ function triggerElement(id) {
   return getBpmnJS().invoke(function(bpmnjs) {
 
     const domElement = domQuery(
-      `.djs-overlays[data-container-id="${id}"] .context-pad:not(.hidden)`,
+      `.djs-overlays[data-container-id="${id}"] .bts-context-pad:not(.hidden)`,
       bpmnjs._container
     );
 
@@ -650,7 +650,7 @@ function triggerScope(scope) {
   return getBpmnJS().invoke(function(bpmnjs) {
 
     const domElement = domQuery(
-      `.token-simulation-scopes [data-scope-id="${scope.id}"]`,
+      `.bts-scopes [data-scope-id="${scope.id}"]`,
       bpmnjs._container
     );
 


### PR DESCRIPTION
Prefix CSS with `bts` prefix.

Closes https://github.com/bpmn-io/bpmn-js-token-simulation/issues/30

----

#### BREAKING CHANGES:

* Generated markup and used CSS classes changed; things are consistently
  prefixed with `bts` now to avoid foreign classes crashing.