### PR TITLE
fix(EditorActions): don't trigger simulation actions when disabled

### DIFF
--- a/lib/features/editor-actions/EditorActions.js
+++ b/lib/features/editor-actions/EditorActions.js
@@ -1,3 +1,5 @@
+import { TOGGLE_MODE_EVENT } from '../../util/EventHelper';
+
 export default function EditorActions(
     eventBus,
     toggleMode,
@@ -6,6 +8,8 @@ export default function EditorActions(
     editorActions,
     injector
 ) {
+  var active = false;
+
   editorActions.register({
     toggleTokenSimulation: function() {
       toggleMode.toggleMode();
@@ -14,13 +18,13 @@ export default function EditorActions(
 
   editorActions.register({
     togglePauseTokenSimulation: function() {
-      pauseSimulation.toggle();
+      active && pauseSimulation.toggle();
     }
   });
 
   editorActions.register({
     resetTokenSimulation: function() {
-      resetSimulation.resetSimulation();
+      active && resetSimulation.resetSimulation();
     }
   });
 
@@ -30,6 +34,10 @@ export default function EditorActions(
     toggleTokenSimulationLog: function() {
       log.toggle();
     }
+  });
+
+  eventBus.on(TOGGLE_MODE_EVENT, (event) => {
+    active = event.active;
   });
 }
 


### PR DESCRIPTION
This prevents the invalid state of "disabled but controls active" from occurring.

related to https://github.com/camunda/camunda-modeler-token-simulation-plugin/issues/60
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
