### PR TITLE
Exclusive gateway without outgoings

### DIFF
--- a/lib/simulator/behaviors/ExclusiveGatewayBehavior.js
+++ b/lib/simulator/behaviors/ExclusiveGatewayBehavior.js
@@ -3,7 +3,8 @@ import {
 } from '../util/ModelUtil';
 
 
-export default function ExclusiveGatewayBehavior(simulator) {
+export default function ExclusiveGatewayBehavior(simulator, scopeBehavior) {
+  this._scopeBehavior = scopeBehavior;
   this._simulator = simulator;
 
   simulator.registerBehavior('bpmn:ExclusiveGateway', this);
@@ -39,7 +40,7 @@ ExclusiveGatewayBehavior.prototype.exit = function(context) {
   const outgoing = outgoings.find(o => o === activeOutgoing);
 
   if (!outgoing) {
-    throw new Error('no outgoing configured');
+    return this._scopeBehavior.tryExit(scope.parent, scope);
   }
 
   return this._simulator.enter({
@@ -48,4 +49,7 @@ ExclusiveGatewayBehavior.prototype.exit = function(context) {
   });
 };
 
-ExclusiveGatewayBehavior.$inject = [ 'simulator' ];
+ExclusiveGatewayBehavior.$inject = [
+  'simulator',
+  'scopeBehavior'
+];

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
@@ -5,7 +5,7 @@
       <outgoing>Flow_1</outgoing>
     </startEvent>
     <sequenceFlow id="Flow_1" sourceRef="START" targetRef="G_A" />
-    <exclusiveGateway id="G_A" name="G_A">
+    <exclusiveGateway id="EXCLUSIVE_GATEWAY" name="EXCLUSIVE_GATEWAY">
       <incoming>Flow_1</incoming>
     </exclusiveGateway>
   </process>

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
@@ -4,7 +4,7 @@
     <startEvent id="START" name="START">
       <outgoing>Flow_1</outgoing>
     </startEvent>
-    <sequenceFlow id="Flow_1" sourceRef="START" targetRef="G_A" />
+    <sequenceFlow id="Flow_1" sourceRef="START" targetRef="EXCLUSIVE_GATEWAY" />
     <exclusiveGateway id="EXCLUSIVE_GATEWAY" name="EXCLUSIVE_GATEWAY">
       <incoming>Flow_1</incoming>
     </exclusiveGateway>

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="8.3.1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="START" name="START">
+      <outgoing>Flow_1</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_1" sourceRef="START" targetRef="G_A" />
+    <exclusiveGateway id="G_A" name="G_A">
+      <incoming>Flow_1</incoming>
+    </exclusiveGateway>
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="START_di" bpmnElement="START">
+        <omgdc:Bounds x="172" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="172" y="148" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="G_A_di" bpmnElement="G_A" isMarkerVisible="true">
+        <omgdc:Bounds x="265" y="165" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="324.5" y="183" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <omgdi:waypoint x="208" y="190" />
+        <omgdi:waypoint x="265" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.bpmn
@@ -17,7 +17,7 @@
           <omgdc:Bounds x="172" y="148" width="36" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="G_A_di" bpmnElement="G_A" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="EXCLUSIVE_GATEWAY_di" bpmnElement="EXCLUSIVE_GATEWAY" isMarkerVisible="true">
         <omgdc:Bounds x="265" y="165" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="324.5" y="183" width="23" height="14" />

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
@@ -12,7 +12,7 @@
   "destroyScope:Flow_1:D",
   "enter:G_A:B",
   "exit:G_A:E",
-  "destroyScope:G_A:E",
+  "destroyScope:EXCLUSIVE_GATEWAY:E",
   "exit:Process_1:B",
   "destroyScope:Process_1:B"
 ]

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
@@ -8,7 +8,7 @@
   "destroyScope:START:C",
   "enter:Flow_1:B",
   "exit:Flow_1:D",
-  "createScope:G_A:B",
+  "createScope:EXCLUSIVE_GATEWAY:B",
   "destroyScope:Flow_1:D",
   "enter:EXCLUSIVE_GATEWAY:B",
   "exit:G_A:E",

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
@@ -1,0 +1,18 @@
+[
+  "createScope:Process_1:null",
+  "signal:Process_1:B",
+  "createScope:START:B",
+  "signal:START:C",
+  "exit:START:C",
+  "createScope:Flow_1:B",
+  "destroyScope:START:C",
+  "enter:Flow_1:B",
+  "exit:Flow_1:D",
+  "createScope:G_A:B",
+  "destroyScope:Flow_1:D",
+  "enter:G_A:B",
+  "exit:G_A:E",
+  "destroyScope:G_A:E",
+  "exit:Process_1:B",
+  "destroyScope:Process_1:B"
+]

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
@@ -11,7 +11,7 @@
   "createScope:EXCLUSIVE_GATEWAY:B",
   "destroyScope:Flow_1:D",
   "enter:EXCLUSIVE_GATEWAY:B",
-  "exit:G_A:E",
+  "exit:EXCLUSIVE_GATEWAY:E",
   "destroyScope:EXCLUSIVE_GATEWAY:E",
   "exit:Process_1:B",
   "destroyScope:Process_1:B"

--- a/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
+++ b/test/spec/simulator/Simulator.exclusive-gateway-no-outgoings.json
@@ -10,7 +10,7 @@
   "exit:Flow_1:D",
   "createScope:G_A:B",
   "destroyScope:Flow_1:D",
-  "enter:G_A:B",
+  "enter:EXCLUSIVE_GATEWAY:B",
   "exit:G_A:E",
   "destroyScope:EXCLUSIVE_GATEWAY:E",
   "exit:Process_1:B",

--- a/test/spec/simulator/SimulatorSpec.js
+++ b/test/spec/simulator/SimulatorSpec.js
@@ -447,6 +447,7 @@ describe('simulator', function() {
       expectTrace(fixture());
     });
 
+
     verify('exclusive-gateway-no-outgoings', (fixture) => {
 
       // when

--- a/test/spec/simulator/SimulatorSpec.js
+++ b/test/spec/simulator/SimulatorSpec.js
@@ -447,6 +447,17 @@ describe('simulator', function() {
       expectTrace(fixture());
     });
 
+    verify('exclusive-gateway-no-outgoings', (fixture) => {
+
+      // when
+      trigger({
+        element: element('START')
+      });
+
+      // then
+      expectTrace(fixture());
+    });
+
 
     verify('task-join', (fixture) => {
 


### PR DESCRIPTION
Fixes #134 

### Before:

https://github.com/bpmn-io/bpmn-js-token-simulation/assets/102799465/c0f0ae9f-b293-45f7-a6a2-1d6207642337

### After:

https://github.com/bpmn-io/bpmn-js-token-simulation/assets/102799465/c413565f-9603-4023-93de-292ebb7f829e



### Changes

I've added the ScopeBehavior to the ExclusiveGatewayBehavior module to make use of its tryExit() method to terminate the simulation if there are no outgoings for a given exclusive gateway. As far as i understood the tryExit() method is the general way to terminate a simulation.

I also saw that the ParallelGatewayBehavior handles its exit function via the exit method of the [ActivityBehavior](https://github.com/bpmn-io/bpmn-js-token-simulation/blob/master/lib/simulator/behaviors/ActivityBehavior.js) 
https://github.com/bpmn-io/bpmn-js-token-simulation/blob/ee251725d54d06761c70d7d98ae775512f66ea32/lib/simulator/behaviors/ParallelGatewayBehavior.js#L49-L51 

The corresponding checks (e.g. if there are no outgoings) are then done inside the exit() method of the ActivityBehavior. I tried doing the same for the exclusive gateway behavior. While it also led to the desired outcome and i could not find any issues during functional testing, some unit tests failed. I also found it a little confusing that the ParallelGatewayBehavior called the exit function of the ActivityBehavior, which also includes activity-specific checks, that are not particularly useful  for gateways.

While i do think grouping this checks instead of writing them in every behavior module makes a lot of sense (e.g. checking if there are outgoings has to be done for every process element i think?), there may be an easier structure to it. E.g. the have behaviors for every supported element and inherit complementary functionality from its more general element. Here is an example: ParallelGatewayBehavior does x that is exclusive for parallel gateways, does y from GatewayBehavior that is exclusive for gateways and does z from ElementBehavior that is mandatory for every element. It's not in scope of this bug but just came to my mind when working on it.

Regarding your request to also write a test case for it, i was not quite sure how to create a corresponding json. Is there any kind of documentation?

Thanks in advance and kind regards from Viadee,
Luka
