### PR TITLE
fix: hide all other overlays when token simulation active

### DIFF
--- a/assets/css/bpmn-js-token-simulation.css
+++ b/assets/css/bpmn-js-token-simulation.css
@@ -254,16 +254,17 @@
   top: 60px;
 }
 
-.bjs-container.simulation .djs-palette {
-  display: none;
-}
-
-.bjs-container.simulation .djs-outline,
 .bjs-container.simulation .djs-bendpoint,
-.bjs-container.simulation .djs-segment-dragger,
-.bjs-container.simulation .djs-resizer {
+.bjs-container.simulation .djs-outline,
+.bjs-container.simulation .djs-palette,
+.bjs-container.simulation .djs-resizer,
+.bjs-container.simulation .djs-segment-dragger {
   display: none !important;
 }
+
+.bjs-container.simulation .djs-overlay:not(.djs-overlay-bts-context-menu, .djs-overlay-bts-element-notification, .djs-overlay-bts-token-count) {
+  display: none !important;
+} 
 
 .bts-palette {
   position: absolute;

--- a/lib/features/context-pads/ContextPads.js
+++ b/lib/features/context-pads/ContextPads.js
@@ -162,7 +162,7 @@ ContextPads.prototype._addOverlay = function(element, options) {
     throw new Error('<handlerHash> required');
   }
 
-  const overlayId = this._overlays.add(element, 'ts-context-menu', {
+  const overlayId = this._overlays.add(element, 'bts-context-menu', {
     ...options,
     position: {
       top: OFFSET_TOP,

--- a/lib/features/disable-modeling/DisableModeling.js
+++ b/lib/features/disable-modeling/DisableModeling.js
@@ -22,7 +22,6 @@ export default function DisableModeling(
 
     if (modelingDisabled) {
       directEditing.cancel();
-      contextPad.close();
       dragging.cancel();
     }
 
@@ -55,8 +54,6 @@ export default function DisableModeling(
       return fn.apply(this, args);
     });
   }
-
-  ignoreIfModelingDisabled(contextPad, 'open');
 
   ignoreIfModelingDisabled(dragging, 'init');
 

--- a/lib/features/disable-modeling/DisableModeling.js
+++ b/lib/features/disable-modeling/DisableModeling.js
@@ -12,8 +12,7 @@ export default function DisableModeling(
     directEditing,
     editorActions,
     modeling,
-    palette,
-    paletteProvider) {
+    palette) {
 
   let modelingDisabled = false;
 
@@ -119,8 +118,7 @@ DisableModeling.$inject = [
   'directEditing',
   'editorActions',
   'modeling',
-  'palette',
-  'paletteProvider',
+  'palette'
 ];
 
 

--- a/lib/features/element-notifications/ElementNotifications.js
+++ b/lib/features/element-notifications/ElementNotifications.js
@@ -50,7 +50,7 @@ ElementNotifications.prototype.addElementNotification = function(element, option
     </div>
   `);
 
-  this._overlays.add(element, 'element-notification', {
+  this._overlays.add(element, 'bts-element-notification', {
     position,
     html: html,
     show: {
@@ -60,7 +60,7 @@ ElementNotifications.prototype.addElementNotification = function(element, option
 };
 
 ElementNotifications.prototype.clear = function() {
-  this._overlays.remove({ type: 'element-notification' });
+  this._overlays.remove({ type: 'bts-element-notification' });
 };
 
 ElementNotifications.prototype.removeElementNotification = function(element) {

--- a/lib/features/token-count/TokenCount.js
+++ b/lib/features/token-count/TokenCount.js
@@ -90,7 +90,7 @@ TokenCount.prototype.addTokenCount = function(element, scopes) {
 
   const position = { bottom: OFFSET_BOTTOM, left: OFFSET_LEFT };
 
-  const overlayId = this._overlays.add(element, 'token-count', {
+  const overlayId = this._overlays.add(element, 'bts-token-count', {
     position: position,
     html: html,
     show: {


### PR DESCRIPTION
* hide all other overlays when simulation active
* don't interfere with context pad (overlay hidden through CSS)

Closes #160
Related to https://github.com/bpmn-io/bpmn-js-token-simulation/issues/161
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
