### PR TITLE
fix: undefined eventDefinitions on some elements

### DIFF
--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -52,7 +52,7 @@ function getIconForIntermediateEvent(element, throwOrCatch) {
 
 function getEventTypeString(element) {
   const bo = getBusinessObject(element);
-  if (bo.eventDefinitions === undefined || bo.eventDefinitions.length === 0) {
+  if (bo.get('eventDefinitions').length === 0) {
     return 'none';
   }
   const eventDefinition = bo.eventDefinitions[0];

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -52,7 +52,7 @@ function getIconForIntermediateEvent(element, throwOrCatch) {
 
 function getEventTypeString(element) {
   const bo = getBusinessObject(element);
-  if (bo.eventDefinitions.length === 0) {
+  if (bo.eventDefinitions === undefined || bo.eventDefinitions.length === 0) {
     return 'none';
   }
   const eventDefinition = bo.eventDefinitions[0];


### PR DESCRIPTION
This MR is fixing the businessObject.eventDefinitions undefined exception received on some elements.

Fix for events failing at `bo.eventDefinitions.length` as undefined on some elements.