### PR TITLE
fix(Log): add aria-label to close button

### DIFF
--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -358,7 +358,7 @@ Log.prototype._init = function() {
       <div class="bts-header">
         ${ LogIcon('bts-log-icon') }
         Simulation Log
-        <button class="bts-close">
+        <button class="bts-close" aria-label="Close">
           ${ TimesIcon() }
         </button>
       </div>


### PR DESCRIPTION
### Proposed Changes

Make close button accessible.

closes #177

Steps to reproduce:
- check out branch
- open log
- check AXE dev tools
- no `Buttons must have discernible Text` Issue is shown

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] ~~**Visual demo** attached~~ No visual changes
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
