### PR TITLE
show drilldown overlay in simulation mode

### DIFF
--- a/assets/css/bpmn-js-token-simulation.css
+++ b/assets/css/bpmn-js-token-simulation.css
@@ -258,7 +258,7 @@
   display: none !important;
 }
 
-.bjs-container.simulation .djs-overlay:not(.djs-overlay-bts-context-menu, .djs-overlay-bts-element-notification, .djs-overlay-bts-token-count) {
+.bjs-container.simulation .djs-overlay:not(.djs-overlay-bts-context-menu, .djs-overlay-bts-element-notification, .djs-overlay-bts-token-count, .djs-overlay-drilldown) {
   display: none !important;
 } 
 

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -288,6 +288,25 @@ describe('modeler extension', function() {
       expect(overlays.every(element => window.getComputedStyle(element).display === 'none')).to.be.true;
     }));
 
+
+    it('should not hide drilldown', inject(function(bpmnReplace, elementRegistry, toggleMode) {
+
+      // given
+      const task = elementRegistry.get('Task_3');
+      bpmnReplace.replaceElement(task, { type: 'bpmn:SubProcess', isExpanded: false });
+
+      const overlays = Array.from(domQueryAll('.djs-overlay-drilldown'));
+
+      expect(overlays).to.have.length.greaterThan(0);
+      expect(overlays.every(element => window.getComputedStyle(element).display !== 'none')).to.be.true;
+
+      // when
+      toggleMode.toggleMode();
+
+      // then
+      expect(overlays.every(element => window.getComputedStyle(element).display !== 'none')).to.be.true;
+    }));
+
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

Closes #188

The drilldown overlay on sub processes is now visible again while token simulation is active.

<details>
<summary>Demo</summary>

![visual-demo](https://github.com/user-attachments/assets/efc7bcde-c3df-413c-9e14-cb1ff7ea23fa)
</details>