### PR TITLE
Do not hide parent token on active children

### DIFF
--- a/lib/features/token-count/TokenCount.js
+++ b/lib/features/token-count/TokenCount.js
@@ -66,7 +66,7 @@ TokenCount.prototype.addTokenCounts = function(element) {
   const scopes = this._simulator.findScopes(scope => {
     return (
       !scope.destroyed &&
-      scope.children.some(c => !c.destroyed && c.element === element && !c.children.length)
+      scope.children.some(c => !c.destroyed && c.element === element)
     );
   });
 


### PR DESCRIPTION
### Proposed Changes

This is a more general solution to https://github.com/bpmn-io/bpmn-js-token-simulation/issues/204 that will always show active parent tokens on an element, no matter if the sub-process is collapsed or expanded.

Closes https://github.com/bpmn-io/bpmn-js-token-simulation/issues/204

#### Before (scope tokens hidden on child activity)

![image](https://github.com/user-attachments/assets/0dfcde63-ff17-4aae-836f-f7dc8aeab48b)

#### Proposed (scope tokens shown bouncing on child activity)

![screenshot j7kr2v](https://github.com/user-attachments/assets/637a5dc0-79cd-4715-aca7-27f66f956c26)


<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
