### PR TITLE
Show all sub process scopes

### DIFF
--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -10,6 +10,7 @@ import {
 import {
   getBusinessObject,
   is,
+  isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
@@ -130,7 +131,7 @@ export default function Log(
       'bpmn:SubProcess'
     ];
 
-    if (!processScopes.includes(scopeElement.type)) {
+    if (!isAny(scopeElement, processScopes)) {
       return;
     }
 
@@ -164,7 +165,7 @@ export default function Log(
       'bpmn:SubProcess'
     ];
 
-    if (!processScopes.includes(scopeElement.type)) {
+    if (!isAny(scopeElement, processScopes)) {
       return;
     }
 

--- a/lib/features/show-scopes/ShowScopes.js
+++ b/lib/features/show-scopes/ShowScopes.js
@@ -8,6 +8,10 @@ import {
 } from 'min-dom';
 
 import {
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
   TOGGLE_MODE_EVENT,
   SCOPE_CREATE_EVENT,
   SCOPE_CHANGED_EVENT,
@@ -102,7 +106,7 @@ ShowScopes.prototype.addScope = function(scope) {
     element: scopeElement
   } = scope;
 
-  if (!processElements.includes(scopeElement.type)) {
+  if (!isAny(scopeElement, processElements)) {
     return;
   }
 

--- a/test/spec/features/log/LogSpec.js
+++ b/test/spec/features/log/LogSpec.js
@@ -8,6 +8,10 @@ import {
   getBpmnJS,
 } from 'test/TestHelper';
 
+import {
+  CheckCircleIcon
+} from 'lib/icons';
+
 import Log from 'lib/features/log/Log';
 
 const TestModule = {
@@ -410,6 +414,73 @@ describe('features/log', function() {
           {
             'icon': 'bpmn-icon-gateway-or',
             'text': 'Inclusive'
+          },
+          {
+            'icon': 'bpmn-icon-end-event-none',
+            'text': 'End Event'
+          }
+        ]);
+      }
+    ));
+
+  });
+
+
+  describe('items - sub processes', function() {
+
+    const diagram = require('./sub-processes.bpmn');
+
+    beforeEach(bootstrapModeler(diagram, {
+      additionalModules: [
+        ModelerModule,
+        TestModule,
+        {
+          log: [ 'type', LogCollector ]
+        },
+      ]
+    }));
+
+    beforeEach(inject(function(simulationSupport) {
+      simulationSupport.toggleSimulation();
+    }));
+
+
+    it('should be logged', inject(
+      async function() {
+
+        // when
+        triggerElement('StartEvent_1');
+        await elementEnter('EndEvent_1');
+
+        // then
+        expectLog([
+          {
+            'icon': 'bpmn-icon-start-event-none',
+            'text': 'Start Event'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess started'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess finished'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess started'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess finished'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess started'
+          },
+          {
+            'icon': CheckCircleIcon(),
+            'text': 'SubProcess finished'
           },
           {
             'icon': 'bpmn-icon-end-event-none',

--- a/test/spec/features/log/sub-processes.bpmn
+++ b/test/spec/features/log/sub-processes.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18b3zn3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_186nk6c" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="TransactionExpanded" targetRef="AdHocExpanded" />
+    <bpmn:transaction id="TransactionExpanded">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:transaction>
+    <bpmn:adHocSubProcess id="AdHocExpanded">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="AdHocExpanded" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EmbeddedExpanded" />
+    <bpmn:subProcess id="EmbeddedExpanded">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="EmbeddedExpanded" targetRef="TransactionExpanded" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_186nk6c">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wwmphf_di" bpmnElement="TransactionExpanded" isExpanded="true">
+        <dc:Bounds x="545" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xiyzrh_di" bpmnElement="AdHocExpanded" isExpanded="true">
+        <dc:Bounds x="825" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b2kj71_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1092" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cfson9_di" bpmnElement="EmbeddedExpanded" isExpanded="true">
+        <dc:Bounds x="265" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16gcolc_di" bpmnElement="Flow_3">
+        <di:waypoint x="755" y="140" />
+        <di:waypoint x="825" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lnm1jn_di" bpmnElement="Flow_4">
+        <di:waypoint x="1035" y="140" />
+        <di:waypoint x="1092" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cam5k2_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="140" />
+        <di:waypoint x="265" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0al35a1_di" bpmnElement="Flow_2">
+        <di:waypoint x="475" y="140" />
+        <di:waypoint x="545" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/show-scopes/ShowScopesSpec.js
+++ b/test/spec/features/show-scopes/ShowScopesSpec.js
@@ -1,0 +1,186 @@
+import ModelerModule from 'lib/modeler';
+
+import SimulationSupportModule from 'lib/simulation-support';
+
+import {
+  bootstrapModeler as _bootstrapModeler,
+  inject,
+  getBpmnJS,
+} from 'test/TestHelper';
+
+import { queryAll as domQueryAll } from 'min-dom';
+
+const TestModule = {
+  __depends__: [
+    SimulationSupportModule
+  ],
+  __init__: [
+    function(animation) {
+      animation.setAnimationSpeed(100);
+    }
+  ]
+};
+
+function bootstrapModeler(diagram, config) {
+  const {
+    animation = {},
+    ...restConfig
+  } = config;
+
+  return _bootstrapModeler(diagram, {
+    ...restConfig,
+    animation: {
+      randomize: false,
+      ...animation
+    }
+  });
+}
+
+
+describe('features/show-scopes', function() {
+
+  describe('process', function() {
+
+    const diagram = require('./processes.bpmn');
+
+    beforeEach(bootstrapModeler(diagram, {
+      additionalModules: [
+        ModelerModule,
+        TestModule,
+      ]
+    }));
+
+    beforeEach(inject(function(simulationSupport) {
+      simulationSupport.toggleSimulation();
+    }));
+
+
+    it('should show scope', inject(
+      async function() {
+
+        // when
+        triggerElement('StartEvent_1');
+
+        await elementEnter('WaitingTask_1');
+
+        // then
+        const scopeElements = getScopeElements();
+        expect(scopeElements.length).equals(1);
+
+        // but when
+        triggerElement('StartEvent_2');
+
+        await elementEnter('WaitingTask_2');
+
+        // then
+        const scopeElements2 = getScopeElements();
+        expect(scopeElements2.length).equals(2);
+      }
+    ));
+
+  });
+
+
+  describe('sub-process', function() {
+
+    const diagram = require('./sub-processes.bpmn');
+
+    beforeEach(bootstrapModeler(diagram, {
+      additionalModules: [
+        ModelerModule,
+        TestModule,
+      ]
+    }));
+
+    beforeEach(inject(function(simulationSupport) {
+      simulationSupport.toggleSimulation();
+    }));
+
+
+    it('should show scopes', inject(
+      async function() {
+
+        // when
+        triggerElement('StartEvent_1');
+
+        await elementEnter('WaitingTask_1');
+
+        // then
+        const scopeElements1 = getScopeElements();
+        expect(scopeElements1.length).equals(2);
+
+        // and when
+        triggerElement('WaitingTask_1');
+
+        await elementEnter('WaitingTask_2');
+
+        // then
+        const scopeElements2 = getScopeElements();
+        expect(scopeElements2.length).equals(2);
+
+        // and when
+        triggerElement('WaitingTask_2');
+
+        await elementEnter('WaitingTask_3');
+
+        // then
+        const scopeElements3 = getScopeElements();
+        expect(scopeElements3.length).equals(2);
+      }
+    ));
+
+  });
+
+
+  describe('event sub-process', function() {
+
+    const diagram = require('./event-sub-processes.bpmn');
+
+    beforeEach(bootstrapModeler(diagram, {
+      additionalModules: [
+        ModelerModule,
+        TestModule,
+      ]
+    }));
+
+    beforeEach(inject(function(simulationSupport) {
+      simulationSupport.toggleSimulation();
+    }));
+
+
+    it('should show scopes', inject(
+      async function() {
+
+        // when
+        triggerElement('StartEvent_1');
+
+        await elementEnter('WaitingTask_2');
+
+        // then
+        const scopeElements = getScopeElements();
+        expect(scopeElements.length).equals(3);
+      }
+    ));
+
+  });
+
+});
+
+
+// helpers ////////////////////
+
+function getScopeElements() {
+  return Array.from(domQueryAll('.bts-scopes > .bts-scope'));
+}
+
+function getSimulationSupport() {
+  return getBpmnJS().get('simulationSupport');
+}
+
+function triggerElement(...args) {
+  return getSimulationSupport().triggerElement(...args);
+}
+
+function elementEnter(...args) {
+  return getSimulationSupport().elementEnter(...args);
+}

--- a/test/spec/features/show-scopes/event-sub-processes.bpmn
+++ b/test/spec/features/show-scopes/event-sub-processes.bpmn
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_15ddevr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_19h0qyx" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EscalationEndEvent_1" />
+    <bpmn:endEvent id="EscalationEndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0k0bdfe" />
+    </bpmn:endEvent>
+    <bpmn:subProcess id="EventSubProcess_1" triggeredByEvent="true">
+      <bpmn:startEvent id="EscalationStartEvent_1" isInterrupting="false">
+        <bpmn:outgoing>Flow_2</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_04k7mun" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_2" sourceRef="EscalationStartEvent_1" targetRef="WaitingTask_1" />
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>Flow_3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_3" sourceRef="WaitingTask_1" targetRef="EndEvent_1" />
+      <bpmn:receiveTask id="WaitingTask_1">
+        <bpmn:incoming>Flow_2</bpmn:incoming>
+        <bpmn:outgoing>Flow_3</bpmn:outgoing>
+      </bpmn:receiveTask>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EventSubProcess_2" name="Escalation Handler" triggeredByEvent="true">
+      <bpmn:startEvent id="EscalationStartEvent_2" isInterrupting="false">
+        <bpmn:outgoing>Flow_4</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0o9lwlx" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_4" sourceRef="EscalationStartEvent_2" targetRef="WaitingTask_2" />
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>Flow_5</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_5" sourceRef="WaitingTask_2" targetRef="EndEvent_2" />
+      <bpmn:receiveTask id="WaitingTask_2">
+        <bpmn:incoming>Flow_4</bpmn:incoming>
+        <bpmn:outgoing>Flow_5</bpmn:outgoing>
+      </bpmn:receiveTask>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_19h0qyx">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1upe6v6_di" bpmnElement="EscalationEndEvent_1">
+        <dc:Bounds x="272" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rku4mv_di" bpmnElement="EventSubProcess_1" isExpanded="true">
+        <dc:Bounds x="210" y="160" width="330" height="180" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rpjshx_di" bpmnElement="EscalationStartEvent_1">
+        <dc:Bounds x="240" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rspjuc_di" bpmnElement="WaitingTask_1">
+        <dc:Bounds x="320" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0forayo_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="472" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0qabzdd_di" bpmnElement="Flow_2">
+        <di:waypoint x="276" y="250" />
+        <di:waypoint x="320" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11s8d40_di" bpmnElement="Flow_3">
+        <di:waypoint x="420" y="250" />
+        <di:waypoint x="472" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_01fyc91_di" bpmnElement="EventSubProcess_2" isExpanded="false">
+        <dc:Bounds x="570" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0goguqm_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="272" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="EventSubProcess_2">
+      <bpmndi:BPMNShape id="Event_0rubob3_di" bpmnElement="EscalationStartEvent_2">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vefiu3_di" bpmnElement="EndEvent_2">
+        <dc:Bounds x="432" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00d1o5b_di" bpmnElement="WaitingTask_2">
+        <dc:Bounds x="270" y="138" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1ds228j_di" bpmnElement="Flow_4">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tl5bae_di" bpmnElement="Flow_5">
+        <di:waypoint x="370" y="178" />
+        <di:waypoint x="432" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/show-scopes/processes.bpmn
+++ b/test/spec/features/show-scopes/processes.bpmn
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0ps1sta" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:collaboration id="Collaboration_0cosjqq">
+    <bpmn:participant id="Participant_1" name="Process A" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" name="Process B" processRef="Process_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="WaitingTask_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="WaitingTask_1" targetRef="EndEvent_1" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:receiveTask id="WaitingTask_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:receiveTask>
+  </bpmn:process>
+  <bpmn:process id="Process_2" isExecutable="false">
+    <bpmn:sequenceFlow id="Flow_11" sourceRef="StartEvent_2" targetRef="WaitingTask_2" />
+    <bpmn:sequenceFlow id="Flow_12" sourceRef="WaitingTask_2" targetRef="EndEvent_2" />
+    <bpmn:startEvent id="StartEvent_2">
+      <bpmn:outgoing>Flow_11</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_2">
+      <bpmn:incoming>Flow_12</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:receiveTask id="WaitingTask_2">
+      <bpmn:incoming>Flow_11</bpmn:incoming>
+      <bpmn:outgoing>Flow_12</bpmn:outgoing>
+    </bpmn:receiveTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0cosjqq">
+      <bpmndi:BPMNShape id="Participant_01vr1n1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="132" y="85" width="370" height="170" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1n5vj1c_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="422" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0oioc9e_di" bpmnElement="WaitingTask_1">
+        <dc:Bounds x="270" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1282pc6_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="170" />
+        <di:waypoint x="270" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nwg8oy_di" bpmnElement="Flow_2">
+        <di:waypoint x="370" y="170" />
+        <di:waypoint x="422" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0daqavg_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="132" y="280" width="370" height="170" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h8ivgr_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="182" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17qgowb_di" bpmnElement="EndEvent_2">
+        <dc:Bounds x="422" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0aug645_di" bpmnElement="WaitingTask_2">
+        <dc:Bounds x="270" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1vw1tlu_di" bpmnElement="Flow_11">
+        <di:waypoint x="218" y="360" />
+        <di:waypoint x="270" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g0mvgd_di" bpmnElement="Flow_12">
+        <di:waypoint x="370" y="360" />
+        <di:waypoint x="422" y="360" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/show-scopes/scoper.bpmn
+++ b/test/spec/features/show-scopes/scoper.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18b3zn3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_186nk6c" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_6" sourceRef="TransactionExpanded" targetRef="AdHocExpanded" />
+    <bpmn:transaction id="TransactionExpanded">
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+      <bpmn:outgoing>Flow_6</bpmn:outgoing>
+      <bpmn:receiveTask id="Activity_1bmdv4y" />
+    </bpmn:transaction>
+    <bpmn:adHocSubProcess id="AdHocExpanded">
+      <bpmn:incoming>Flow_6</bpmn:incoming>
+      <bpmn:outgoing>Flow_7</bpmn:outgoing>
+      <bpmn:receiveTask id="Activity_0hilztc" />
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_7" sourceRef="AdHocExpanded" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EmbeddedExpanded" />
+    <bpmn:subProcess id="EmbeddedExpanded">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+      <bpmn:receiveTask id="Activity_0gffd1w" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="EmbeddedExpanded" targetRef="TransactionExpanded" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_186nk6c">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b2kj71_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1112" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wwmphf_di" bpmnElement="TransactionExpanded" isExpanded="true">
+        <dc:Bounds x="545" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x8l9bt_di" bpmnElement="Activity_1bmdv4y">
+        <dc:Bounds x="600" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xiyzrh_di" bpmnElement="AdHocExpanded" isExpanded="true">
+        <dc:Bounds x="825" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19ced3j_di" bpmnElement="Activity_0hilztc">
+        <dc:Bounds x="880" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cfson9_di" bpmnElement="EmbeddedExpanded" isExpanded="true">
+        <dc:Bounds x="265" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1diifkj_di" bpmnElement="Activity_0gffd1w">
+        <dc:Bounds x="310" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16gcolc_di" bpmnElement="Flow_6">
+        <di:waypoint x="755" y="140" />
+        <di:waypoint x="825" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lnm1jn_di" bpmnElement="Flow_7">
+        <di:waypoint x="1035" y="140" />
+        <di:waypoint x="1112" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cam5k2_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="140" />
+        <di:waypoint x="265" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0al35a1_di" bpmnElement="Flow_5">
+        <di:waypoint x="475" y="140" />
+        <di:waypoint x="545" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/show-scopes/sub-processes.bpmn
+++ b/test/spec/features/show-scopes/sub-processes.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_18b3zn3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_186nk6c" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="TransactionExpanded" targetRef="AdHocExpanded" />
+    <bpmn:transaction id="TransactionExpanded">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+      <bpmn:receiveTask id="WaitingTask_2" />
+    </bpmn:transaction>
+    <bpmn:adHocSubProcess id="AdHocExpanded">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+      <bpmn:receiveTask id="WaitingTask_3" />
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="AdHocExpanded" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EmbeddedExpanded" />
+    <bpmn:subProcess id="EmbeddedExpanded">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:receiveTask id="WaitingTask_1" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="EmbeddedExpanded" targetRef="TransactionExpanded" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_186nk6c">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b2kj71_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1092" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wwmphf_di" bpmnElement="TransactionExpanded" isExpanded="true">
+        <dc:Bounds x="545" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x8l9bt_di" bpmnElement="WaitingTask_2">
+        <dc:Bounds x="600" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xiyzrh_di" bpmnElement="AdHocExpanded" isExpanded="true">
+        <dc:Bounds x="825" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19ced3j_di" bpmnElement="WaitingTask_3">
+        <dc:Bounds x="880" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cfson9_di" bpmnElement="EmbeddedExpanded" isExpanded="true">
+        <dc:Bounds x="265" y="80" width="210" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1diifkj_di" bpmnElement="WaitingTask_1">
+        <dc:Bounds x="320" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16gcolc_di" bpmnElement="Flow_3">
+        <di:waypoint x="755" y="140" />
+        <di:waypoint x="825" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lnm1jn_di" bpmnElement="Flow_4">
+        <di:waypoint x="1035" y="140" />
+        <di:waypoint x="1092" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cam5k2_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="140" />
+        <di:waypoint x="265" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0al35a1_di" bpmnElement="Flow_2">
+        <di:waypoint x="475" y="140" />
+        <di:waypoint x="545" y="140" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

Closes #205

Scopes of transactions and ad-hoc subprocesses are now shown in the Scope Filter bar when they are active.
The Log now shows when these subprocesses start and finish.

There were no tests for the Show Scopes feature, so I created a basic set.

![demo205](https://github.com/user-attachments/assets/47dee093-65fd-4ef6-a289-f607e4ab4a1f)
