### PR TITLE
Allow-list safe editor actions when token simulation is active

### DIFF
--- a/lib/features/disable-modeling/DisableModeling.js
+++ b/lib/features/disable-modeling/DisableModeling.js
@@ -88,18 +88,16 @@ export default function DisableModeling(
   intercept(editorActions, 'trigger', function(fn, args) {
     const action = args[0];
 
-    if (modelingDisabled && isAnyAction([
-      'undo',
-      'redo',
-      'copy',
-      'paste',
-      'removeSelection',
-      'spaceTool',
-      'lassoTool',
-      'globalConnectTool',
-      'distributeElements',
-      'alignElements',
-      'directEditing',
+    // allow list actions permitted,
+    // everything else is likely incompatible with
+    // token simulation mode
+    if (modelingDisabled && !isAnyAction([
+      'toggleTokenSimulation',
+      'toggleTokenSimulationLog',
+      'togglePauseTokenSimulation',
+      'resetTokenSimulation',
+      'stepZoom',
+      'zoom'
     ], action)) {
       return;
     }

--- a/lib/features/keyboard-bindings/KeyboardBindings.js
+++ b/lib/features/keyboard-bindings/KeyboardBindings.js
@@ -55,7 +55,7 @@ export default function KeyboardBindings(eventBus, injector) {
     keyboard.addListener(VERY_HIGH_PRIORITY, function(event) {
       var keyEvent = event.keyEvent;
 
-      handleKeyEvent(keyEvent);
+      return handleKeyEvent(keyEvent);
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Token simulation assumes [full control over editor actions allowed](https://github.com/bpmn-io/bpmn-js-token-simulation/commit/b5e981a8d9b5279ac4d5b65f03415a9d1fb565bd) when the simulation is active + we properly indicate [keyboard shortcuts](https://github.com/bpmn-io/bpmn-js-token-simulation/commit/e2f58a4c3024b2c81f0e8d46fceb08de0f78ff98) as handled to prevent double triggers.

Closes https://github.com/bpmn-io/bpmn-js-token-simulation/issues/203

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
