### PR TITLE
Use bpmn-js core utilities in place of `ElementHelper` exports

### DIFF
--- a/lib/features/context-pads/ContextPads.js
+++ b/lib/features/context-pads/ContextPads.js
@@ -1,6 +1,6 @@
 import {
   is
-} from '../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   TOGGLE_MODE_EVENT,

--- a/lib/features/context-pads/handler/ExclusiveGatewayHandler.js
+++ b/lib/features/context-pads/handler/ExclusiveGatewayHandler.js
@@ -1,6 +1,6 @@
 import {
   is
-} from '../../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   ForkIcon

--- a/lib/features/context-pads/handler/InclusiveGatewayHandler.js
+++ b/lib/features/context-pads/handler/InclusiveGatewayHandler.js
@@ -2,7 +2,10 @@ import {
   ForkIcon
 } from '../../../icons';
 
-import { getBusinessObject } from '../../../util/ElementHelper';
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
 import { isSequenceFlow } from '../../../simulator/util/ModelUtil';
 
 export default function InclusiveGatewayHandler(inclusiveGatewaySettings) {

--- a/lib/features/context-pads/handler/PauseHandler.js
+++ b/lib/features/context-pads/handler/PauseHandler.js
@@ -7,7 +7,7 @@ import {
 import {
   is,
   getBusinessObject
-} from '../../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 
 export default function PauseHandler(simulator) {

--- a/lib/features/element-support/ElementSupport.js
+++ b/lib/features/element-support/ElementSupport.js
@@ -3,8 +3,8 @@ import {
 } from 'min-dom';
 
 import {
-  is
-} from '../../util/ElementHelper';
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   TOGGLE_MODE_EVENT
@@ -59,7 +59,7 @@ ElementSupport.prototype.enable = function() {
       return;
     }
 
-    if (!is(element, UNSUPPORTED_ELEMENTS)) {
+    if (!isAny(element, UNSUPPORTED_ELEMENTS)) {
       return;
     }
 

--- a/lib/features/exclusive-gateway-settings/ExclusiveGatewaySettings.js
+++ b/lib/features/exclusive-gateway-settings/ExclusiveGatewaySettings.js
@@ -1,6 +1,6 @@
 import {
   is
-} from '../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   TOGGLE_MODE_EVENT

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -10,7 +10,7 @@ import {
 import {
   getBusinessObject,
   is,
-} from '../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   escapeHTML

--- a/lib/features/token-count/TokenCount.js
+++ b/lib/features/token-count/TokenCount.js
@@ -6,7 +6,7 @@ import {
 
 import {
   is
-} from '../../util/ElementHelper';
+} from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   ELEMENT_CHANGED_EVENT,

--- a/lib/simulation-support/SimulationSupport.js
+++ b/lib/simulation-support/SimulationSupport.js
@@ -6,7 +6,7 @@ import {
   SCOPE_DESTROYED_EVENT
 } from '../util/EventHelper';
 
-import { is } from '../util/ElementHelper';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 export const ENTER_EVENT = 'trace.elementEnter';
 export const EXIT_EVENT = 'trace.elementExit';

--- a/lib/util/ElementHelper.js
+++ b/lib/util/ElementHelper.js
@@ -4,23 +4,9 @@ import {
 } from 'min-dash';
 
 import {
-  is as __is,
+  is,
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
-
-export function is(element, types) {
-  if (element.type === 'label') {
-    return false;
-  }
-
-  if (!Array.isArray(types)) {
-    types = [ types ];
-  }
-
-  return types.some(function(type) {
-    return __is(element, type);
-  });
-}
 
 export function getEventDefinition(event, eventDefinitionType) {
   return find(getBusinessObject(event).eventDefinitions, definition => {
@@ -33,7 +19,3 @@ export function isTypedEvent(event, eventDefinitionType) {
     return is(definition, eventDefinitionType);
   });
 }
-
-export {
-  getBusinessObject
-};


### PR DESCRIPTION
### Proposed Changes

Allows us to stay aligned with what bpmn-js offers.

Cf. https://github.com/bpmn-io/bpmn-js-token-simulation/pull/210#discussion_r1951169948.

Related to https://github.com/bpmn-io/bpmn-js-token-simulation/pull/210

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
