### PR TITLE
ci: update example only once per push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     - name: Update example
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ matrix.integration-deps == '' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:
         GIT_USER_NAME: ${{secrets.BPMN_IO_USER_NAME}}
         GIT_USER_EMAIL: ${{secrets.BPMN_IO_EMAIL}}


### PR DESCRIPTION
### Proposed Changes

Currently, we update example twice: for latest bpmn-js, and with bpmn-js@17. This seems to break the keyboard binding as the example uses an old diagram-js keyboard implementation.

Cf. https://github.com/bpmn-io/bpmn-js-token-simulation/actions/runs/17493541710/job/49688633072

Closes #236

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
