### PR TITLE
fix: make simulation-support init minification-safe

### DIFF
--- a/lib/simulation-support/SimulationTraceEvents.js
+++ b/lib/simulation-support/SimulationTraceEvents.js
@@ -14,7 +14,7 @@ import {
  *
  * @param {EventBus} eventBus
  */
-export default function TraceEvents(eventBus) {
+export default function SimulationTraceEvents(eventBus) {
   eventBus.on(TRACE_EVENT, function(event) {
 
     if (event.action === 'enter') {
@@ -27,4 +27,4 @@ export default function TraceEvents(eventBus) {
   });
 }
 
-TraceEvents.$inject = [ 'eventBus' ];
+SimulationTraceEvents.$inject = [ 'eventBus' ];

--- a/lib/simulation-support/TraceEvents.js
+++ b/lib/simulation-support/TraceEvents.js
@@ -1,0 +1,30 @@
+import {
+  TRACE_EVENT
+} from '../util/EventHelper';
+
+import {
+  ENTER_EVENT,
+  EXIT_EVENT
+} from './SimulationSupport';
+
+
+/**
+ * Emits dedicated element enter and exit events based on the
+ * simulation trace.
+ *
+ * @param {EventBus} eventBus
+ */
+export default function TraceEvents(eventBus) {
+  eventBus.on(TRACE_EVENT, function(event) {
+
+    if (event.action === 'enter') {
+      eventBus.fire(ENTER_EVENT, event);
+    }
+
+    if (event.action === 'exit') {
+      eventBus.fire(EXIT_EVENT, event);
+    }
+  });
+}
+
+TraceEvents.$inject = [ 'eventBus' ];

--- a/lib/simulation-support/index.js
+++ b/lib/simulation-support/index.js
@@ -1,29 +1,11 @@
 import SimulationTrace from './SimulationTrace';
 import SimulationSupport from './SimulationSupport';
-
-import {
-  TRACE_EVENT
-} from '../util/EventHelper';
-
-import {
-  ENTER_EVENT,
-  EXIT_EVENT
-} from './SimulationSupport';
+import TraceEvents from './TraceEvents';
 
 
 export default {
-  __init__: [ [ 'eventBus', function(eventBus) {
-    eventBus.on(TRACE_EVENT, function(event) {
-
-      if (event.action === 'enter') {
-        eventBus.fire(ENTER_EVENT, event);
-      }
-
-      if (event.action === 'exit') {
-        eventBus.fire(EXIT_EVENT, event);
-      }
-    });
-  } ] ],
+  __init__: [ 'traceEvents' ],
+  traceEvents: [ 'type', TraceEvents ],
   simulationTrace: [ 'type', SimulationTrace ],
   simulationSupport: [ 'type', SimulationSupport ]
 };

--- a/lib/simulation-support/index.js
+++ b/lib/simulation-support/index.js
@@ -12,7 +12,7 @@ import {
 
 
 export default {
-  __init__: [ 'eventBus', function(eventBus) {
+  __init__: [ [ 'eventBus', function(eventBus) {
     eventBus.on(TRACE_EVENT, function(event) {
 
       if (event.action === 'enter') {
@@ -23,7 +23,7 @@ export default {
         eventBus.fire(EXIT_EVENT, event);
       }
     });
-  } ],
+  } ] ],
   simulationTrace: [ 'type', SimulationTrace ],
   simulationSupport: [ 'type', SimulationSupport ]
 };

--- a/lib/simulation-support/index.js
+++ b/lib/simulation-support/index.js
@@ -1,11 +1,11 @@
 import SimulationTrace from './SimulationTrace';
 import SimulationSupport from './SimulationSupport';
-import TraceEvents from './TraceEvents';
+import SimulationTraceEvents from './SimulationTraceEvents';
 
 
 export default {
-  __init__: [ 'traceEvents' ],
-  traceEvents: [ 'type', TraceEvents ],
+  __init__: [ 'simulationTraceEvents' ],
+  simulationTraceEvents: [ 'type', SimulationTraceEvents ],
   simulationTrace: [ 'type', SimulationTrace ],
   simulationSupport: [ 'type', SimulationSupport ]
 };


### PR DESCRIPTION
The anonymous `__init__` function in `lib/simulation-support/index.js` relies on the injector's argument name parsing to resolve `eventBus`:

```js
__init__: [ 'eventBus', function(eventBus) { ... } ]
```

When the module is bundled into an application that minifies with parameter mangling (e.g. terser with `mangle` enabled), the parameter is renamed and the injector fails on `Modeler` creation:

```
Error: No provider for "e"! (Resolving: boundaryEventBehavior -> e)
```

This appears to be the only place in the library that relies on parameter name parsing — every other module uses `$inject` or array notation.

Fixed by switching the init function to array notation, consistent with `lib/simulator/index.js`:

```js
__init__: [ [ 'eventBus', function(eventBus) { ... } ] ]
```

No behavior change otherwise. `npm run all` passes locally (the 5 `Invalid Chai property` failures in `ModelerSpec`/`SimulatorSpec` reproduce on a clean `main` checkout as well and are unrelated).