### PR TITLE
Disable modeling through @bpmn-io/diagram-js-canvas-lock

### DIFF
--- a/assets/css/bpmn-js-token-simulation.css
+++ b/assets/css/bpmn-js-token-simulation.css
@@ -257,12 +257,7 @@
   top: 60px;
 }
 
-.bjs-container.simulation .djs-bendpoint,
-.bjs-container.simulation .djs-context-pad,
-.bjs-container.simulation .djs-outline,
-.bjs-container.simulation .djs-palette,
-.bjs-container.simulation .djs-resizer,
-.bjs-container.simulation .djs-segment-dragger {
+.bjs-container.simulation .djs-palette {
   display: none !important;
 }
 

--- a/example/modeler.html
+++ b/example/modeler.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/bpmn-font/css/bpmn-embedded.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js-token-simulation/assets/css/bpmn-js-token-simulation.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js-properties-panel/assets/properties-panel.css" />
+  <link rel="stylesheet" href="./dist/vendor/diagram-js-canvas-lock/assets/canvas-lock.css" />
   <link rel="stylesheet" href="./style.css" />
 
   <link rel="icon" type="image/png" href="favicon.png" />

--- a/lib/features/disable-modeling/DisableModeling.js
+++ b/lib/features/disable-modeling/DisableModeling.js
@@ -4,121 +4,42 @@ import {
 
 const HIGH_PRIORITY = 10001;
 
+// editor actions that must stay available while the canvas is locked
+const SIMULATION_EDITOR_ACTIONS = [
+  'toggleTokenSimulation',
+  'toggleTokenSimulationLog',
+  'togglePauseTokenSimulation',
+  'resetTokenSimulation'
+];
 
-export default function DisableModeling(
-    eventBus,
-    contextPad,
-    dragging,
-    directEditing,
-    editorActions,
-    modeling,
-    palette) {
 
-  let modelingDisabled = false;
-
-  eventBus.on(TOGGLE_MODE_EVENT, HIGH_PRIORITY, event => {
-
-    modelingDisabled = event.active;
-
-    if (modelingDisabled) {
-      directEditing.cancel();
-      dragging.cancel();
+/**
+ * Locks the canvas while token simulation is active by delegating to the
+ * `canvasLock` service. Keeps token simulation's own editor actions available
+ * while the canvas is locked.
+ *
+ * @param {import('diagram-js/lib/core/EventBus').default} eventBus
+ * @param {import('@bpmn-io/diagram-js-canvas-lock').CanvasLock} canvasLock
+ */
+export default function DisableModeling(eventBus, canvasLock) {
+  eventBus.on(TOGGLE_MODE_EVENT, function(event) {
+    if (event.active) {
+      canvasLock.lock();
+    } else {
+      canvasLock.unlock();
     }
-
-    palette._update();
   });
 
-  function intercept(obj, fnName, cb) {
-    const fn = obj[fnName];
-    obj[fnName] = function() {
-      return cb.call(this, fn, arguments);
-    };
-  }
-
-  function ignoreIfModelingDisabled(obj, fnName) {
-    intercept(obj, fnName, function(fn, args) {
-      if (modelingDisabled) {
-        return;
-      }
-
-      return fn.apply(this, args);
-    });
-  }
-
-  function throwIfModelingDisabled(obj, fnName) {
-    intercept(obj, fnName, function(fn, args) {
-      if (modelingDisabled) {
-        throw new Error('model is read-only');
-      }
-
-      return fn.apply(this, args);
-    });
-  }
-
-  ignoreIfModelingDisabled(dragging, 'init');
-
-  ignoreIfModelingDisabled(directEditing, 'activate');
-
-  ignoreIfModelingDisabled(dragging, 'init');
-
-  ignoreIfModelingDisabled(directEditing, 'activate');
-
-  throwIfModelingDisabled(modeling, 'moveShape');
-  throwIfModelingDisabled(modeling, 'updateAttachment');
-  throwIfModelingDisabled(modeling, 'moveElements');
-  throwIfModelingDisabled(modeling, 'moveConnection');
-  throwIfModelingDisabled(modeling, 'layoutConnection');
-  throwIfModelingDisabled(modeling, 'createConnection');
-  throwIfModelingDisabled(modeling, 'createShape');
-  throwIfModelingDisabled(modeling, 'createLabel');
-  throwIfModelingDisabled(modeling, 'appendShape');
-  throwIfModelingDisabled(modeling, 'removeElements');
-  throwIfModelingDisabled(modeling, 'distributeElements');
-  throwIfModelingDisabled(modeling, 'removeShape');
-  throwIfModelingDisabled(modeling, 'removeConnection');
-  throwIfModelingDisabled(modeling, 'replaceShape');
-  throwIfModelingDisabled(modeling, 'pasteElements');
-  throwIfModelingDisabled(modeling, 'alignElements');
-  throwIfModelingDisabled(modeling, 'resizeShape');
-  throwIfModelingDisabled(modeling, 'createSpace');
-  throwIfModelingDisabled(modeling, 'updateWaypoints');
-  throwIfModelingDisabled(modeling, 'reconnectStart');
-  throwIfModelingDisabled(modeling, 'reconnectEnd');
-
-  intercept(editorActions, 'trigger', function(fn, args) {
-    const action = args[0];
-
-    // allow list actions permitted,
-    // everything else is likely incompatible with
-    // token simulation mode
-    if (modelingDisabled && !isAnyAction([
-      'toggleTokenSimulation',
-      'toggleTokenSimulationLog',
-      'togglePauseTokenSimulation',
-      'resetTokenSimulation',
-      'stepZoom',
-      'zoom'
-    ], action)) {
-      return;
+  // run before canvasLock's blocker (priority 10000); returning `true` halts
+  // propagation and keeps the simulation's own actions available while locked
+  eventBus.on('editorActions.allowed', HIGH_PRIORITY, function(event) {
+    if (SIMULATION_EDITOR_ACTIONS.includes(event.action)) {
+      return true;
     }
-
-    return fn.apply(this, args);
   });
 }
 
 DisableModeling.$inject = [
   'eventBus',
-  'contextPad',
-  'dragging',
-  'directEditing',
-  'editorActions',
-  'modeling',
-  'palette'
+  'canvasLock'
 ];
-
-
-// helpers //////////
-
-function isAnyAction(actions, action) {
-  return actions.indexOf(action) > -1;
-}

--- a/lib/modeler.js
+++ b/lib/modeler.js
@@ -1,4 +1,5 @@
 import BaseModule from './base';
+import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
 import DisableModelingModule from './features/disable-modeling';
 
 import ToggleModeModule from './features/toggle-mode/modeler';
@@ -8,6 +9,7 @@ import TokenSimulationKeyboardBindingsModule from './features/keyboard-bindings'
 export default {
   __depends__: [
     BaseModule,
+    CanvasLockModule,
     DisableModelingModule,
     ToggleModeModule,
     TokenSimulationEditorActionsModule,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@bpmn-io/properties-panel": "^3.40.5",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
-        "bpmn-js": "^18.13.2",
+        "bpmn-js": "^18.19.0",
         "bpmn-js-properties-panel": "^5.53.0",
         "chai": "^6.2.2",
         "copy-webpack-plugin": "^14.0.0",
@@ -2801,19 +2801,19 @@
       }
     },
     "node_modules/bpmn-js": {
-      "version": "18.13.2",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.13.2.tgz",
-      "integrity": "sha512-OSsCknc5J7lnLFZxyK9hET4dxCV+k44mvI3QmbWkgbmBwPsNgV9CzI6FS8aIV5uea4rgBGS+Xscs0+wuDZQKNA==",
+      "version": "18.19.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.19.0.tgz",
+      "integrity": "sha512-MxEUdk1zLuf4ie8Bf0Pbr/zYMhzOhi+5LAm3669lormD1vP3XQaOoBNKkdeyJVz3aZmXzT+YbfNAYNUj9goLFQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.10.0",
-        "diagram-js-direct-editing": "^3.3.0",
-        "ids": "^3.0.0",
+        "diagram-js": "^15.18.0",
+        "diagram-js-direct-editing": "^3.4.0",
+        "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
+        "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.39.4",
       "license": "MIT",
       "dependencies": {
+        "@bpmn-io/diagram-js-canvas-lock": "^0.1.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
@@ -433,14 +434,29 @@
         ]
       }
     },
+    "node_modules/@bpmn-io/diagram-js-canvas-lock": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-canvas-lock/-/diagram-js-canvas-lock-0.1.0.tgz",
+      "integrity": "sha512-97sF+juqMeet4XdbU9lWUM8jWXLm7pNLBsDIcWz7+sGPqoZwAB8bQusOIMQiAPU9YGgliwj3b0o0kLP5h2jk1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "diagram-js": ">= 15.16.0",
+        "diagram-js-direct-editing": ">= 3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "diagram-js-direct-editing": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
-      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "dev": true,
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
+      "integrity": "sha512-I678ZGtoH7z7FgzFhzzppM9ThsJ3Lh83kW3GjhjG3xyYciIPYHMaHK1MABP8F69H9pFZpViM6t4qUo8dwrVz0w==",
+      "license": "MIT",
       "dependencies": {
         "htm": "^3.1.1",
-        "preact": "^10.11.2"
+        "preact": "^10.29.2"
       }
     },
     "node_modules/@bpmn-io/extract-process-variables": {
@@ -3170,7 +3186,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3705,13 +3720,12 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.10.0.tgz",
-      "integrity": "sha512-M9Wia5kGOzF5vxVVO/GHlql9mL9gntjGXSIfpJcs8pryCq1z1aNFjqeKmtJC9RcrPsop74QDDqcDVZNoaH/agQ==",
-      "dev": true,
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.18.0.tgz",
+      "integrity": "sha512-aOVeXrjQc1ki0jlrSuwXDoye5nKO6uAtXCtmgQopUvF/aC9aJwoaBOsNvQ2Na9GmMc6X2b3xAefhRChvGgcbgQ==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
+        "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
@@ -3726,10 +3740,10 @@
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
-      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
-      "dev": true,
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.4.0.tgz",
+      "integrity": "sha512-eXfd+nxJr5xt3YlCrs+E53mPi+gqBWRBkAXkR99ZPL7Pl0B3H5nkv/uiwx4Q4vJU/Sp8Jy3zVdhP/Y2c6loTjw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-dash": "^5.0.0",
@@ -3746,7 +3760,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
       "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.12"
@@ -5455,7 +5468,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true
+      "license": "Apache-2.0"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7492,7 +7505,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7732,7 +7744,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
       "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.20"
@@ -7921,10 +7932,10 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.20.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.1.tgz",
-      "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==",
-      "dev": true,
+      "version": "10.29.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
+      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9472,7 +9483,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
       "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "webpack-dev-server": "^5.2.3"
   },
   "dependencies": {
+    "@bpmn-io/diagram-js-canvas-lock": "^0.1.0",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@bpmn-io/properties-panel": "^3.40.5",
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
-    "bpmn-js": "^18.13.2",
+    "bpmn-js": "^18.19.0",
     "bpmn-js-properties-panel": "^5.53.0",
     "chai": "^6.2.2",
     "copy-webpack-plugin": "^14.0.0",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -15,6 +15,8 @@ export function injectStyles() {
 
   bpmnJsSatisfies('>= 9') && insertCSS('bpmn-js.css', require('bpmn-js/dist/assets/bpmn-js.css'));
 
+  insertCSS('canvas-lock.css', require('@bpmn-io/diagram-js-canvas-lock/assets/canvas-lock.css'));
+
   insertCSS('bpmn-js-token-simulation.css', require('../assets/css/bpmn-js-token-simulation.css'));
 
   insertCSS('diagram-js-testing.css',

--- a/test/spec/DisableModelingSpec.js
+++ b/test/spec/DisableModelingSpec.js
@@ -1,0 +1,85 @@
+import TokenSimulationModelerModules from '../..';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import { expect } from 'chai';
+
+
+describe('disable modeling', function() {
+
+  const diagram = require('./simple.bpmn');
+
+  beforeEach(bootstrapModeler(diagram, {
+    additionalModules: [
+      TokenSimulationModelerModules
+    ]
+  }));
+
+
+  it('should lock canvas while simulating', inject(
+    function(toggleMode, canvasLock) {
+
+      // assume
+      expect(canvasLock.isLocked()).to.be.false;
+
+      // when
+      toggleMode.toggleMode();
+
+      // then
+      expect(canvasLock.isLocked()).to.be.true;
+    }
+  ));
+
+
+  it('should unlock canvas when leaving simulation', inject(
+    function(toggleMode, canvasLock) {
+
+      // given
+      toggleMode.toggleMode();
+
+      // when
+      toggleMode.toggleMode();
+
+      // then
+      expect(canvasLock.isLocked()).to.be.false;
+    }
+  ));
+
+
+  it('should keep simulation editor actions allowed while locked', inject(
+    function(toggleMode, eventBus) {
+
+      // given
+      toggleMode.toggleMode();
+
+      // when
+      const allowed = eventBus.fire('editorActions.allowed', {
+        action: 'toggleTokenSimulation'
+      });
+
+      // then
+      expect(allowed).to.be.true;
+    }
+  ));
+
+
+  it('should block modeling editor actions while locked', inject(
+    function(toggleMode, eventBus) {
+
+      // given
+      toggleMode.toggleMode();
+
+      // when
+      const allowed = eventBus.fire('editorActions.allowed', {
+        action: 'undo'
+      });
+
+      // then
+      expect(allowed).to.be.false;
+    }
+  ));
+
+});

--- a/test/spec/DisableModelingSpec.js
+++ b/test/spec/DisableModelingSpec.js
@@ -82,4 +82,19 @@ describe('disable modeling', function() {
     }
   ));
 
+
+  it('should block the context pad while locked', inject(
+    function(toggleMode, eventBus) {
+
+      // given
+      toggleMode.toggleMode();
+
+      // when
+      const allowed = eventBus.fire('contextPad.open.allowed');
+
+      // then
+      expect(allowed).to.be.false;
+    }
+  ));
+
 });

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -221,7 +221,6 @@ describe('modeler extension', function() {
       const ui = domQueryAll(`
         .djs-bendpoint,
         .djs-context-pad,
-        .djs-outline,
         .djs-palette,
         .djs-resizer,
         .djs-segment-dragger

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,8 @@ module.exports = (env, argv) => {
         patterns: [
           { from: './assets', to: 'dist/vendor/bpmn-js-token-simulation/assets' },
           { from: 'bpmn-js/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js/assets' },
-          { from: '@bpmn-io/properties-panel/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-properties-panel/assets' }
+          { from: '@bpmn-io/properties-panel/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-properties-panel/assets' },
+          { from: '@bpmn-io/diagram-js-canvas-lock/assets', context: 'node_modules', to: 'dist/vendor/diagram-js-canvas-lock/assets' }
         ]
       }),
       new DefinePlugin({


### PR DESCRIPTION
### Proposed Changes

<img width="1920" height="911" alt="chrome_hCbHVxkrPu" src="https://github.com/user-attachments/assets/bfd6f3fb-e2ea-49e8-a0e2-cf0f860c4a79" />

Replace the homegrown modeling-disable logic with [`@bpmn-io/diagram-js-canvas-lock`](https://github.com/bpmn-io/diagram-js-canvas-lock).

`DisableModeling` now delegates locking/unlocking to the `canvasLock` service instead of manually vetoing individual events, and `canvasLock` is wired in as a regular dependency in `lib/modeler.js`. This centralizes interaction-blocking (drag, context pad, popup menu, direct editing) behind a single, shared, well-tested mechanism instead of duplicating it here.

Additional changes needed to make the swap work:
- `bpmn-js` bumped to `>= 18.19.0`, which bundles a `diagram-js` version new enough for `ContextPad.open` to fire the `contextPad.open.allowed` veto that `canvasLock` relies on.
- `canvas-lock.css` injected in `TestHelper.js` so its `.djs-canvas-locked` styling applies in tests.
- Simulation still keeps the palette fully hidden via our own CSS rule, since `canvas-lock` only dims palette entries by default.

Related to https://github.com/camunda/camunda-modeler/issues/5916

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)